### PR TITLE
Use README for package long-description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 docstring_parser
 ================
 
+Parse Python docstrings in ReST format
+
 Example usage:
 
-```
+```python
 >>> from docstring_parser import parse
 >>>
 >>>

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     author_email='rr-@sakuya.pl',
     name='docstring_parser',
     long_description=(Path(__file__).parent / 'README.md').read_text(),
+    long_description_content_type='text/markdown',
     version='0.1',
     url='https://github.com/rr-/docstring_parser',
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import setup, find_packages
+from pathlib import Path
 
 setup(
     author='Marcin Kurczewski',
     author_email='rr-@sakuya.pl',
     name='docstring_parser',
-    long_description='Parse Python docstrings in reST format',
+    long_description=(Path(__file__).parent / 'README.md').read_text(),
     version='0.1',
     url='https://github.com/rr-/docstring_parser',
     packages=find_packages(),


### PR DESCRIPTION
Use the repository's README to provide the long-description for the package. This will make the README visible on PyPI