### PR TITLE
Added NumPy-style docstring parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 docstring_parser
 ================
 
-Parse Python docstrings. Currently support ReST-style and Google-style
-docstrings.
+Parse Python docstrings. Currently supports ReST-style, NumPy-style and
+Google-style docstrings.
 
 Example usage:
 

--- a/docstring_parser/parser/__init__.py
+++ b/docstring_parser/parser/__init__.py
@@ -5,14 +5,23 @@ import enum
 from . import google, rest
 from .common import Docstring, ParseError
 
+try:
+    from . import numpy
+except ImportError:
+    numpy = None
+
 
 class Style(enum.Enum):
     rest = enum.auto()
     google = enum.auto()
     auto = enum.auto()
+    if numpy:
+        numpy = enum.auto()
 
 
 _styles = {Style.rest: rest.parse, Style.google: google.parse}
+if numpy:
+    _styles[Style.numpy] = numpy.parse
 
 
 def parse(text: str, style: Style = Style.auto) -> Docstring:

--- a/docstring_parser/parser/numpy.py
+++ b/docstring_parser/parser/numpy.py
@@ -1,0 +1,67 @@
+"""NumPy-style docstring parsing."""
+
+from numpydoc import docscrape
+
+from .common import ParseError, Docstring, DocstringMeta
+
+
+def parse(text: str) -> Docstring:
+    """
+    Parse the NumPy-style docstring into its components.
+
+    :returns: parsed docstring
+    """
+    ret = Docstring()
+    if not text:
+        return ret
+
+    try:
+        doc = docscrape.NumpyDocString(text)
+    except (docscrape.ParseError, ValueError) as e:
+        raise ParseError(
+            f'Failed to parse NumPy docstring "{text}"'
+        ) from e
+
+    if any(doc["Summary"]):
+        short = "\n".join(doc["Summary"])
+        ret.short_description = short
+        short_pos = text.index(doc["Summary"][-1])
+        after_short_pos = short_pos + len(doc["Summary"][-1])
+        after_short = text[after_short_pos:after_short_pos + 2]
+        ret.blank_after_short_description = after_short == "\n\n"
+
+    if doc["Extended Summary"] or doc["Notes"]:
+        long_desc = doc["Extended Summary"] + doc["Notes"]
+        ret.long_description = "\n".join(long_desc)
+        long_pos = text.index(long_desc[-1])
+        after_long_pos = long_pos + len(long_desc[-1])
+        after_long = text[after_long_pos:after_long_pos + 2]
+        ret.blank_after_long_description = after_long == "\n\n"
+
+    for arg_name, type_name, desc in doc["Parameters"]:
+        if type_name:
+            args = ["param", type_name, arg_name]
+        else:
+            args = ["param", arg_name]
+        ret.meta.append(DocstringMeta(args, description="\n".join(desc)))
+
+    for type_name, _, desc in doc["Raises"]:
+        args = ["raises", type_name]
+        ret.meta.append(DocstringMeta(args, description="\n".join(desc)))
+
+    if doc["Returns"]:
+        arg_name, type_name, desc = doc["Returns"][0]
+        if type_name:
+            args = ["returns", type_name]
+        else:
+            args = ["returns", arg_name]
+        ret.meta.append(DocstringMeta(args, description="\n".join(desc)))
+    elif doc["Yields"]:
+        type_name, _, desc = doc["Yields"][0]
+        if type_name:
+            args = ["yields", type_name]
+        else:
+            args = ["yields"]
+        ret.meta.append(DocstringMeta(args, description="\n".join(desc)))
+
+    return ret

--- a/docstring_parser/tests/parser/test_numpy.py
+++ b/docstring_parser/tests/parser/test_numpy.py
@@ -1,0 +1,311 @@
+import typing as T
+
+import pytest
+
+from docstring_parser import ParseError
+from docstring_parser.parser.numpy import parse
+
+
+@pytest.mark.parametrize("source, expected", [
+    ("", None),
+    ("\n", None),
+    ("Short description", "Short description"),
+    ("\nShort description\n", "Short description"),
+    ("\n   Short description\n", "Short description"),
+])
+def test_short_description(source: str, expected: str) -> None:
+    docstring = parse(source)
+    assert docstring.short_description == expected
+    assert docstring.long_description is None
+    assert docstring.meta == []
+
+
+@pytest.mark.parametrize(
+    "source, expected_short_desc, expected_long_desc, expected_blank",
+    [
+        (
+            "Short description\n\nLong description",
+            "Short description",
+            "Long description",
+            True
+        ),
+
+        (
+            """
+            Short description
+
+            Long description
+            """,
+            "Short description",
+            "Long description",
+            True
+        ),
+
+        (
+            """
+            Short description
+
+            Long description
+            Second line
+            """,
+            "Short description",
+            "Long description\nSecond line",
+            True
+        ),
+
+        (
+            """
+            Short description
+            """,
+            "Short description",
+            None,
+            False
+        ),
+    ]
+)
+def test_long_description(
+        source: str,
+        expected_short_desc: str,
+        expected_long_desc: str,
+        expected_blank: bool
+) -> None:
+    docstring = parse(source)
+    assert docstring.short_description == expected_short_desc
+    assert docstring.long_description == expected_long_desc
+    assert docstring.blank_after_short_description == expected_blank
+    assert docstring.meta == []
+
+
+@pytest.mark.parametrize(
+    "source, expected_short_desc, expected_long_desc, "
+    "expected_blank_short_desc, expected_blank_long_desc",
+    [
+        (
+            """
+            Short description
+    
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description", None, False, False
+        ),
+
+        (
+            """
+            Short description
+
+            Long description
+
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description", "Long description", True, True
+        ),
+
+        (
+            """
+            Short description
+
+            First line
+                Second line
+
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description", "First line\n    Second line", True, True
+        ),
+
+        (
+            """
+            Parameters
+            ----------
+            asd
+            """,
+            None, None, False, False
+        )
+    ]
+)
+def test_meta_newlines(
+        source: str,
+        expected_short_desc: T.Optional[str],
+        expected_long_desc: T.Optional[str],
+        expected_blank_short_desc: bool,
+        expected_blank_long_desc: bool
+) -> None:
+    docstring = parse(source)
+    assert docstring.short_description == expected_short_desc
+    assert docstring.long_description == expected_long_desc
+    assert docstring.blank_after_short_description == expected_blank_short_desc
+    assert docstring.blank_after_long_description == expected_blank_long_desc
+    assert len(docstring.meta) == 1
+
+
+def test_meta_with_multiline_description() -> None:
+    docstring = parse(
+        """
+        Short description
+
+        Parameters
+        ----------
+        spam
+            asd
+            1
+                2
+            3
+        """)
+    assert docstring.short_description == "Short description"
+    assert len(docstring.meta) == 1
+    assert docstring.meta[0].args == ["param", "spam"]
+    assert docstring.meta[0].description == "asd\n1\n    2\n3"
+
+
+def test_multiple_meta() -> None:
+    docstring = parse(
+        """
+        Short description
+
+        Parameters
+        ----------
+        spam
+            asd
+            1
+                2
+            3
+    
+            Raises
+        ------
+        bla
+            herp
+        yay
+            derp
+        """)
+    assert docstring.short_description == "Short description"
+    assert len(docstring.meta) == 3
+    assert docstring.meta[0].args == ["param", "spam"]
+    assert docstring.meta[0].description == "asd\n1\n    2\n3"
+    assert docstring.meta[1].args == ["raises", "bla"]
+    assert docstring.meta[1].description == "herp"
+    assert docstring.meta[2].args == ["raises", "yay"]
+    assert docstring.meta[2].description == "derp"
+
+
+def test_params() -> None:
+    docstring = parse("Short description")
+    assert len(docstring.params) == 0
+
+    docstring = parse(
+        """
+        Short description
+
+        Parameters
+        ----------
+        name
+            description 1
+        priority : int
+            description 2
+        sender : str
+            description 3
+        """)
+    assert len(docstring.params) == 3
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == "description 1"
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+    assert docstring.params[2].arg_name == "sender"
+    assert docstring.params[2].type_name == "str"
+    assert docstring.params[2].description == "description 3"
+
+
+def test_returns() -> None:
+    docstring = parse(
+        """
+        Short description
+        """)
+    assert docstring.returns is None
+
+    docstring = parse(
+        """
+        Short description
+
+        Returns
+        -------
+        int
+            description
+        """)
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "int"
+    assert docstring.returns.description == "description"
+
+    docstring = parse(
+        """
+        Short description
+
+        Returns
+        -------
+        out : int
+            description
+        """)
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "int"
+    assert docstring.returns.description == "description"
+
+    docstring = parse(
+        """
+        Short description
+
+        Yields
+        ------
+        int
+            description
+        """)
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "int"
+    assert docstring.returns.description == "description"
+
+
+def test_raises() -> None:
+    docstring = parse(
+        """
+        Short description
+        """)
+    assert len(docstring.raises) == 0
+
+    docstring = parse(
+        """
+        Short description
+
+        Raises
+        ------
+        ValueError
+            description
+        """)
+    assert len(docstring.raises) == 1
+    assert docstring.raises[0].type_name == "ValueError"
+    assert docstring.raises[0].description == "description"
+
+
+def test_broken_meta() -> None:
+    with pytest.raises(ParseError):
+        parse(
+            """
+            Short description
+
+            Returns
+            -------
+            out : int
+                description
+
+            Yields
+            ------
+            int
+                description
+            """)
+
+    # these should not raise any errors
+    parse(":sthstrange: desc")
+    parse(":param with too many args: desc")

--- a/docstring_parser/tests/test_parser.py
+++ b/docstring_parser/tests/test_parser.py
@@ -87,3 +87,56 @@ def test_google() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "tuple"
     assert docstring.returns.description == "ret desc"
+
+
+def test_numpy() -> None:
+    docstring = parse(
+        """
+        Short description
+        
+        Long description
+        
+        Causing people to indent:
+        
+            A lot sometimes
+
+        Parameters
+        ----------
+        spam
+            spam desc
+        bla : int
+            bla desc
+        yay : str
+        
+        Raises
+        ------
+        ValueError
+            exc desc
+        
+        Returns
+        -------
+        tuple
+            ret desc
+        """)
+    assert docstring.short_description == "Short description"
+    assert docstring.long_description == (
+        "Long description\n\n"
+        "Causing people to indent:\n\n"
+        "    A lot sometimes"
+    )
+    assert len(docstring.params) == 3
+    assert docstring.params[0].arg_name == "spam"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == "spam desc"
+    assert docstring.params[1].arg_name == "bla"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "bla desc"
+    assert docstring.params[2].arg_name == "yay"
+    assert docstring.params[2].type_name == "str"
+    assert docstring.params[2].description == ""
+    assert len(docstring.raises) == 1
+    assert docstring.raises[0].type_name == "ValueError"
+    assert docstring.raises[0].description == "exc desc"
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "tuple"
+    assert docstring.returns.description == "ret desc"

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     version="0.3",
     url="https://github.com/rr-/docstring_parser",
     packages=find_packages(),
+    extras_require={"numpy": ["numpydoc"]},
     classifiers=[
         "Environment :: Other Environment",
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Support NumPy-style docstrings through the use of the `numpydoc` package. Unfortunately, `numpydoc` depends on the heavy `Sphinx` and `Jinja2` packages, so `numpy` support has been made an optional extra (via `pip3 install docstring_parser[numpy]`)