### PR TITLE
Added fix for complex return type

### DIFF
--- a/docstring_parser/common.py
+++ b/docstring_parser/common.py
@@ -60,7 +60,7 @@ class DocstringReturns(DocstringMeta):
         self,
         args: T.List[str],
         description: str,
-        type_name: str,
+        type_name: T.Optional[str],
         is_generator: bool,
     ) -> None:
         """Initialize self."""
@@ -73,7 +73,7 @@ class DocstringRaises(DocstringMeta):
     """DocstringMeta symbolizing :raises metadata."""
 
     def __init__(
-        self, args: T.List[str], description: str, type_name: str
+        self, args: T.List[str], description: str, type_name: T.Optional[str]
     ) -> None:
         """Initialize self."""
         super().__init__(args, description)

--- a/docstring_parser/google.py
+++ b/docstring_parser/google.py
@@ -38,6 +38,8 @@ class Section(namedtuple("SectionBase", "title key type")):
 
 
 GOOGLE_TYPED_ARG_REGEX = re.compile(r"\s*(.+?)\s*\(\s*(.*[^\s]+)\s*\)")
+MULTIPLE_PATTERN = re.compile(r"(\s*[^:\s]+:)|([^:]*\]:.*)")
+
 DEFAULT_SECTIONS = [
     Section("Arguments", "param", SectionType.MULTIPLE),
     Section("Args", "param", SectionType.MULTIPLE),
@@ -95,7 +97,7 @@ class GoogleParser:
 
         if (
             section.type == SectionType.SINGULAR_OR_MULTIPLE
-            and ":" not in text.split()[0]
+            and not MULTIPLE_PATTERN.match(text)
         ) or section.type == SectionType.SINGULAR:
             return self._build_single_meta(section, text)
 

--- a/docstring_parser/tests/test_google.py
+++ b/docstring_parser/tests/test_google.py
@@ -411,12 +411,33 @@ def test_returns() -> None:
         """
         Short description
         Returns:
+            description with: a colon!
+        """
+    )
+    assert docstring.returns is not None
+    assert docstring.returns.type_name is None
+    assert docstring.returns.description == "description with: a colon!"
+
+    docstring = parse(
+        """
+        Short description
+        Returns:
             int: description
         """
     )
     assert docstring.returns is not None
     assert docstring.returns.type_name == "int"
     assert docstring.returns.description == "description"
+
+    docstring = parse(
+        """
+        Returns:
+            Optional[Mapping[str, List[int]]]: A description: with a colon
+        """
+    )
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "Optional[Mapping[str, List[int]]]"
+    assert docstring.returns.description == "A description: with a colon"
 
     docstring = parse(
         """


### PR DESCRIPTION
Hi @rr- 

Got another fix. Made a pull request this time.

Fails to parse this:

```python
        """
        Returns:
            Optional[Mapping[str, List[int]]]: A description: with a colon
        """
```

Rob