### PR TITLE
Don't include license file as part of the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.md

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     url="https://github.com/rr-/docstring_parser",
     packages=find_packages(),
     package_dir={"docstring_parser": "docstring_parser"},
-    package_data={"docstring_parser": ["../LICENSE.md"]},
     classifiers=[
         "Environment :: Other Environment",
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Including the license file LICENSE.md as part of the package data meant that the file was installed into the user's package directory 'site-packages/'. Declaring the file in MANIFEST.in keeps the license file as part of the source-distribution, and the built-distribution (wheel) automatically finds license files already.