### PR TITLE
google: made attributes param keywords

### DIFF
--- a/docstring_parser/common.py
+++ b/docstring_parser/common.py
@@ -2,7 +2,15 @@
 
 import typing as T
 
-PARAM_KEYWORDS = {"param", "parameter", "arg", "argument", "key", "keyword"}
+PARAM_KEYWORDS = {
+    "param",
+    "parameter",
+    "arg",
+    "argument",
+    "attribute",
+    "key",
+    "keyword",
+}
 RAISES_KEYWORDS = {"raises", "raise", "except", "exception"}
 RETURNS_KEYWORDS = {"return", "returns"}
 YIELDS_KEYWORDS = {"yield", "yields"}

--- a/docstring_parser/tests/test_google.py
+++ b/docstring_parser/tests/test_google.py
@@ -346,7 +346,6 @@ def test_params() -> None:
             priority (int): description 2
             sender (str?): description 3
             ratio (Optional[float], optional): description 4
-
         """
     )
     assert len(docstring.params) == 4
@@ -372,6 +371,60 @@ def test_params() -> None:
         Short description
 
         Args:
+            name: description 1
+                with multi-line text
+            priority (int): description 2
+        """
+    )
+    assert len(docstring.params) == 2
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == (
+        "description 1\n" "with multi-line text"
+    )
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+
+
+def test_attributes() -> None:
+    docstring = parse("Short description")
+    assert len(docstring.params) == 0
+
+    docstring = parse(
+        """
+        Short description
+
+        Attributes:
+            name: description 1
+            priority (int): description 2
+            sender (str?): description 3
+            ratio (Optional[float], optional): description 4
+        """
+    )
+    assert len(docstring.params) == 4
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == "description 1"
+    assert not docstring.params[0].is_optional
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+    assert not docstring.params[1].is_optional
+    assert docstring.params[2].arg_name == "sender"
+    assert docstring.params[2].type_name == "str"
+    assert docstring.params[2].description == "description 3"
+    assert docstring.params[2].is_optional
+    assert docstring.params[3].arg_name == "ratio"
+    assert docstring.params[3].type_name == "Optional[float]"
+    assert docstring.params[3].description == "description 4"
+    assert docstring.params[3].is_optional
+
+    docstring = parse(
+        """
+        Short description
+
+        Attributes:
             name: description 1
                 with multi-line text
             priority (int): description 2


### PR DESCRIPTION
Attributes share the same structure as Args in google docstrings, so can be parsed in the same way.