### PR TITLE
common: add default to param

### DIFF
--- a/docstring_parser/common.py
+++ b/docstring_parser/common.py
@@ -53,12 +53,14 @@ class DocstringParam(DocstringMeta):
         arg_name: str,
         type_name: T.Optional[str],
         is_optional: T.Optional[bool],
+        default: T.Optional[str]
     ) -> None:
         """Initialize self."""
         super().__init__(args, description)
         self.arg_name = arg_name
         self.type_name = type_name
         self.is_optional = is_optional
+        self.default = default
 
 
 class DocstringReturns(DocstringMeta):

--- a/docstring_parser/google.py
+++ b/docstring_parser/google.py
@@ -38,6 +38,7 @@ class Section(namedtuple("SectionBase", "title key type")):
 
 
 GOOGLE_TYPED_ARG_REGEX = re.compile(r"\s*(.+?)\s*\(\s*(.*[^\s]+)\s*\)")
+GOOGLE_ARG_DESC_REGEX = re.compile(r".*\. Defaults to (.+)\.")
 MULTIPLE_PATTERN = re.compile(r"(\s*[^:\s]+:)|([^:]*\]:.*)")
 
 DEFAULT_SECTIONS = [
@@ -146,12 +147,17 @@ class GoogleParser:
             else:
                 arg_name, type_name = before, None
                 is_optional = None
+
+            m = GOOGLE_ARG_DESC_REGEX.match(desc)
+            default = m.group(1) if m else None
+
             return DocstringParam(
                 args=[section.key, before],
                 description=desc,
                 arg_name=arg_name,
                 type_name=type_name,
                 is_optional=is_optional,
+                default=default,
             )
         if section.key in RETURNS_KEYWORDS | YIELDS_KEYWORDS:
             return DocstringReturns(

--- a/docstring_parser/rest.py
+++ b/docstring_parser/rest.py
@@ -38,12 +38,16 @@ def _build_meta(args: T.List[str], desc: str) -> DocstringMeta:
                 f"Expected one or two arguments for a {key} keyword."
             )
 
+        m = re.match(r'.*defaults to (.+)', desc)
+        default = m.group(1).rstrip('.') if m else None
+
         return DocstringParam(
             args=args,
             description=desc,
             arg_name=arg_name,
             type_name=type_name,
             is_optional=is_optional,
+            default=default,
         )
 
     if key in RETURNS_KEYWORDS | YIELDS_KEYWORDS:

--- a/docstring_parser/tests/test_google.py
+++ b/docstring_parser/tests/test_google.py
@@ -304,6 +304,26 @@ def test_meta_with_multiline_description() -> None:
     assert docstring.meta[0].description == "asd\n1\n    2\n3"
 
 
+def test_default_args():
+    docstring = parse(
+    """A sample function
+
+    A function the demonstrates docstrings
+    
+    Args:
+        arg1 (int): The firsty arg
+        arg2 (str): The second arg
+        arg3 (float, optional): The third arg. Defaults to 1.0.
+        arg4 (Optional[Dict[str, Any]], optional): The fourth arg. Defaults to None.
+        arg5 (str, optional): The fifth arg. Defaults to DEFAULT_ARG5.
+    
+    Returns:
+        Mapping[str, Any]: The args packed in a mapping
+    """
+    )
+    assert docstring is not None
+
+
 def test_multiple_meta() -> None:
     docstring = parse(
         """

--- a/docstring_parser/tests/test_rest.py
+++ b/docstring_parser/tests/test_rest.py
@@ -253,21 +253,30 @@ def test_params() -> None:
         :param name: description 1
         :param int priority: description 2
         :param str? sender: description 3
+        :param str? message: description 4, defaults to 'hello'
         """
     )
-    assert len(docstring.params) == 3
+    assert len(docstring.params) == 4
     assert docstring.params[0].arg_name == "name"
     assert docstring.params[0].type_name is None
     assert docstring.params[0].description == "description 1"
+    assert docstring.params[0].default is None
     assert not docstring.params[0].is_optional
     assert docstring.params[1].arg_name == "priority"
     assert docstring.params[1].type_name == "int"
     assert docstring.params[1].description == "description 2"
     assert not docstring.params[1].is_optional
+    assert docstring.params[1].default is None
     assert docstring.params[2].arg_name == "sender"
     assert docstring.params[2].type_name == "str"
     assert docstring.params[2].description == "description 3"
     assert docstring.params[2].is_optional
+    assert docstring.params[2].default is None
+    assert docstring.params[3].arg_name == "message"
+    assert docstring.params[3].type_name == "str"
+    assert docstring.params[3].description == "description 4, defaults to 'hello'"
+    assert docstring.params[3].is_optional
+    assert docstring.params[3].default == "'hello'"
 
 
 def test_returns() -> None:


### PR DESCRIPTION
Added a `default` attribute to `DocstringParam` for google (captures `DEFAULT_ARGS`):

```python
    """A sample function

    A function the demonstrates docstrings
    
    Args:
        arg1 (int): The firsty arg
        arg2 (str): The second arg
        arg3 (float, optional): The third arg. Defaults to 1.0.
        arg4 (Optional[Dict[str, Any]], optional): The fourth arg. Defaults to None.
        arg5 (str, optional): The fifth arg. Defaults to DEFAULT_ARG5.
    
    Returns:
        Mapping[str, Any]: The args packed in a mapping
    """
```

and rest (captures `"hello"`):

```python
        """
        Short description

        :param name: description 1
        :param int priority: description 2
        :param str? sender: description 3
        :param str? message: description 4, defaults to 'hello'
        """
```