### PR TITLE
Fix package installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,5 @@ classifiers =
 
 [options]
 python_requires = ~=3.6
-package_dir = =docstring_parser
-py_modules = docstring_parser
+package_dir = docstring_parser=docstring_parser
+packages = find:


### PR DESCRIPTION
The switch to setup.cfg broke the package installation. This brings it back to how the package installation was in setup.py.

Note: `py_modules` is a list of files to be installed, and should only really be used when installing single-module packages (eg standard-library logging.py). `packages` is for entire packages