### PR TITLE
google: fix comma detection for optional args

### DIFF
--- a/docstring_parser/google.py
+++ b/docstring_parser/google.py
@@ -138,7 +138,7 @@ class GoogleParser:
                 arg_name, type_name = m.group(1, 2)
                 if type_name.endswith(", optional"):
                     is_optional = True
-                    type_name = type_name.rsplit(",")[0]
+                    type_name = type_name[:-10]
                 elif type_name.endswith("?"):
                     is_optional = True
                     type_name = type_name[:-1]

--- a/docstring_parser/tests/test_google.py
+++ b/docstring_parser/tests/test_google.py
@@ -322,6 +322,14 @@ def test_default_args():
     """
     )
     assert docstring is not None
+    assert len(docstring.params) == 5
+
+    arg4 = docstring.params[3]
+    assert arg4.arg_name == "arg4"
+    assert arg4.is_optional
+    assert arg4.type_name == "Optional[Dict[str, Any]]"
+    assert arg4.default == "None"
+    assert arg4.description == "The fourth arg. Defaults to None."
 
 
 def test_multiple_meta() -> None:


### PR DESCRIPTION
Hi @rr- 

The following docstring:

```python
    Args:
        arg (Optional[Dict[str, Any]], optional): An argument. Defaults to None.
```

returns a `type_name` of `"Optional[Dict[str"`.

This should fix it, and I've extended the test.

Rob