### PR TITLE
Adds support for parsing numpydoc-style docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 docstring_parser
 ================
 
-Parse Python docstrings. Currently support ReST-style and Google-style
+Parse Python docstrings. Currently support ReST, Google, and Numpydoc-style
 docstrings.
 
 Example usage:

--- a/docstring_parser/__init__.py
+++ b/docstring_parser/__init__.py
@@ -6,6 +6,7 @@ from .common import (
     DocstringParam,
     DocstringRaises,
     DocstringReturns,
+    DocstringDeprecated,
     ParseError,
 )
 from .parser import parse
@@ -19,5 +20,6 @@ __all__ = [
     "DocstringParam",
     "DocstringRaises",
     "DocstringReturns",
+    "DocstringDeprecated",
     "Style",
 ]

--- a/docstring_parser/common.py
+++ b/docstring_parser/common.py
@@ -49,7 +49,7 @@ class DocstringParam(DocstringMeta):
     def __init__(
         self,
         args: T.List[str],
-        description: str,
+        description: T.Optional[str],
         arg_name: str,
         type_name: T.Optional[str],
         is_optional: T.Optional[bool],
@@ -69,25 +69,45 @@ class DocstringReturns(DocstringMeta):
     def __init__(
         self,
         args: T.List[str],
-        description: str,
+        description: T.Optional[str],
         type_name: T.Optional[str],
         is_generator: bool,
+        return_name: T.Optional[str] = None
     ) -> None:
         """Initialize self."""
         super().__init__(args, description)
         self.type_name = type_name
         self.is_generator = is_generator
+        self.return_name = return_name
 
 
 class DocstringRaises(DocstringMeta):
     """DocstringMeta symbolizing :raises metadata."""
 
     def __init__(
-        self, args: T.List[str], description: str, type_name: T.Optional[str]
+        self,
+        args: T.List[str],
+        description: T.Optional[str],
+        type_name: T.Optional[str]
     ) -> None:
         """Initialize self."""
         super().__init__(args, description)
         self.type_name = type_name
+        self.description = description
+
+
+class DocstringDeprecated(DocstringMeta):
+    """DocstringMeta symbolizing deprecation metadata."""
+
+    def __init__(
+        self,
+        args: T.List[str],
+        description: T.Optional[str],
+        version: T.Optional[str]
+    ) -> None:
+        """Initialize self."""
+        super().__init__(args, description)
+        self.version = version
         self.description = description
 
 
@@ -116,5 +136,12 @@ class Docstring:
     def returns(self) -> T.Optional[DocstringReturns]:
         for item in self.meta:
             if isinstance(item, DocstringReturns):
+                return item
+        return None
+
+    @property
+    def deprecation(self) -> T.Optional[DocstringDeprecated]:
+        for item in self.meta:
+            if isinstance(item, DocstringDeprecated):
                 return item
         return None

--- a/docstring_parser/numpydoc.py
+++ b/docstring_parser/numpydoc.py
@@ -1,0 +1,327 @@
+"""Numpydoc-style docstring parsing.
+
+.. seealso:: https://numpydoc.readthedocs.io/en/latest/format.html
+"""
+
+import inspect
+import re
+import typing as T
+import itertools
+from dataclasses import dataclass
+
+from .common import (
+    Docstring,
+    DocstringMeta,
+    DocstringParam,
+    DocstringRaises,
+    DocstringReturns,
+    DocstringDeprecated,
+)
+
+
+def _pairwise(iterable: T.Iterable, end=None) -> T.Iterable:
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return itertools.zip_longest(a, b, fillvalue=end)
+
+
+def _clean_str(string: str) -> T.Optional[str]:
+    string = string.strip()
+    if len(string) > 0:
+        return string
+
+
+KV_REGEX = re.compile(r'^[^\s].*$', flags=re.M)
+
+PARAM_KEY_REGEX = re.compile(r'^(?P<name>.*?)(?:\s*:\s*(?P<type>.*?))?$')
+
+PARAM_OPTIONAL_REGEX = re.compile(r'(?P<type>.*?)(?:, optional|\(optional\))$')
+
+# numpydoc format has no formal grammar for this,
+# but we can make some educated guesses...
+PARAM_DEFAULT_REGEX = re.compile(
+    r'[Dd]efault(?: is | = |: |s to |)\s*(?P<value>[\w\-\.]+)'
+)
+
+RETURN_KEY_REGEX = re.compile(r'^(?:(?P<name>.*?)\s*:\s*)?(?P<type>.*?)$')
+
+
+@dataclass
+class Section:
+    """Numpydoc section parser.
+
+    :param title: section title. For most sections, this is a heading like
+                  "Parameters" which appears on its own line, underlined by
+                  en-dashes ('-') on the following line.
+    :param key: meta key string. In the parsed ``DocstringMeta`` instance this
+                will be the first element of the ``args`` attribute list.
+    """
+    title: str
+    key: str
+
+    @property
+    def title_pattern(self) -> str:
+        """Regular expression pattern matching this section's header.
+
+        This pattern will match this instance's ``title`` attribute in
+        an anonymous group.
+        """
+        return r"^({})\s*?\n{}\s*$".format(self.title, '-' * len(self.title))
+
+    def parse(self, text: str) -> T.Iterable[DocstringMeta]:
+        """Parse ``DocstringMeta`` objects from the body of this section.
+
+        :param text: section body text. Should be cleaned with
+                     ``inspect.cleandoc`` before parsing.
+        """
+        yield DocstringMeta([self.key], description=_clean_str(text))
+
+
+class _KVSection(Section):
+    """Base parser for numpydoc sections with key-value syntax.
+
+    E.g. sections that look like this:
+        key
+            value
+        key2 : type
+            values can also span...
+            ... multiple lines
+    """
+    def _parse_item(self, key: str, value: str) -> DocstringMeta:
+        pass
+
+    def parse(self, text: str) -> T.Iterable[DocstringMeta]:
+        for match, next_match in _pairwise(KV_REGEX.finditer(text)):
+            start = match.end()
+            end = next_match.start() if next_match is not None else None
+            value = text[start:end]
+            yield self._parse_item(key=match.group(),
+                                   value=inspect.cleandoc(value))
+
+
+class _SphinxSection(Section):
+    """Base parser for numpydoc sections with sphinx-style syntax.
+
+    E.g. sections that look like this:
+        .. title:: something
+            possibly over multiple lines
+    """
+    @property
+    def title_pattern(self) -> str:
+        return r"^\.\.\s*({})\s*::".format(self.title)
+
+
+class ParamSection(_KVSection):
+    """Parser for numpydoc parameter sections.
+
+    E.g. any section that looks like this:
+        arg_name
+            arg_description
+        arg_2 : type, optional
+            descriptions can also span...
+            ... multiple lines
+    """
+    def _parse_item(self, key: str, value: str) -> DocstringParam:
+        m = PARAM_KEY_REGEX.match(key)
+        arg_name = type_name = is_optional = None
+        if m is not None:
+            arg_name, type_name = m.group('name'), m.group('type')
+            if type_name is not None:
+                optional_match = PARAM_OPTIONAL_REGEX.match(type_name)
+                if optional_match is not None:
+                    type_name = optional_match.group('type')
+                    is_optional = True
+                else:
+                    is_optional = False
+
+        default = None
+        if len(value) > 0:
+            default_match = PARAM_DEFAULT_REGEX.search(value)
+            if default_match is not None:
+                default = default_match.group('value')
+
+        return DocstringParam(
+            args=[self.key, arg_name],
+            description=_clean_str(value),
+            arg_name=arg_name,
+            type_name=type_name,
+            is_optional=is_optional,
+            default=default,
+        )
+
+
+class RaisesSection(_KVSection):
+    """Parser for numpydoc raises sections.
+
+    E.g. any section that looks like this:
+        ValueError
+            A description of what might raise ValueError
+    """
+    def _parse_item(self, key: str, value: str) -> DocstringRaises:
+        return DocstringRaises(
+            args=[self.key, key],
+            description=_clean_str(value),
+            type_name=key if len(key) > 0 else None,
+        )
+
+
+class ReturnsSection(_KVSection):
+    """Parser for numpydoc raises sections.
+
+    E.g. any section that looks like this:
+        return_name : type
+            A description of this returned value
+        another_type
+            Return names are optional, types are required
+    """
+    is_generator = False
+
+    def _parse_item(self, key: str, value: str) -> DocstringReturns:
+        m = RETURN_KEY_REGEX.match(key)
+        if m is not None:
+            return_name, type_name = m.group('name'), m.group('type')
+        else:
+            return_name = type_name = None
+
+        return DocstringReturns(
+            args=[self.key],
+            description=_clean_str(value),
+            type_name=type_name,
+            is_generator=self.is_generator,
+            return_name=return_name,
+        )
+
+
+class YieldsSection(ReturnsSection):
+    """Parser for numpydoc generator "yields" sections."""
+    is_generator = True
+
+
+class DeprecationSection(_SphinxSection):
+    """Parser for numpydoc "deprecation warning" sections."""
+    def parse(self, text: str) -> T.Iterable[DocstringDeprecated]:
+        version, desc, *_ = text.split(sep='\n', maxsplit=1) + [None, None]
+
+        if desc is not None:
+            desc = _clean_str(inspect.cleandoc(desc))
+
+        yield DocstringDeprecated(
+            args=[self.key],
+            description=desc,
+            version=_clean_str(version),
+        )
+
+
+DEFAULT_SECTIONS = [
+    ParamSection("Parameters", "param"),
+    ParamSection("Params", "param"),
+    ParamSection("Arguments", "param"),
+    ParamSection("Args", "param"),
+    ParamSection("Other Parameters", "other_param"),
+    ParamSection("Other Params", "other_param"),
+    ParamSection("Other Arguments", "other_param"),
+    ParamSection("Other Args", "other_param"),
+    ParamSection("Receives", "receives"),
+    ParamSection("Receive", "receives"),
+    RaisesSection("Raises", "raises"),
+    RaisesSection("Raise", "raises"),
+    RaisesSection("Warns", "warns"),
+    RaisesSection("Warn", "warns"),
+    ParamSection("Attributes", "attribute"),
+    ParamSection("Attribute", "attribute"),
+    ReturnsSection("Returns", "returns"),
+    ReturnsSection("Return", "returns"),
+    YieldsSection("Yields", "yields"),
+    YieldsSection("Yield", "yields"),
+    Section("Examples", "examples"),
+    Section("Example", "examples"),
+    Section("Warnings", "warnings"),
+    Section("Warning", "warnings"),
+    Section("See Also", "see_also"),
+    Section("Related", "see_also"),
+    Section("Notes", "notes"),
+    Section("Note", "notes"),
+    Section("References", "references"),
+    Section("Reference", "references"),
+    DeprecationSection("deprecated", "deprecation"),
+]
+
+
+class NumpydocParser:
+    def __init__(
+        self, sections: T.Optional[T.Dict[str, Section]] = None
+    ):
+        """Setup sections.
+
+        :param sections: Recognized sections or None to defaults.
+        """
+        sections = sections or DEFAULT_SECTIONS
+        self.sections = {s.title: s for s in sections}
+        self._setup()
+
+    def _setup(self):
+        self.titles_re = re.compile(
+            r"|".join(s.title_pattern for s in self.sections.values()),
+            flags=re.M
+        )
+
+    def add_section(self, section: Section):
+        """Add or replace a section.
+
+        :param section: The new section.
+        """
+
+        self.sections[section.title] = section
+        self._setup()
+
+    def parse(self, text: str) -> Docstring:
+        """Parse the numpy-style docstring into its components.
+
+        :returns: parsed docstring
+        """
+        ret = Docstring()
+        if not text:
+            return ret
+
+        # Clean according to PEP-0257
+        text = inspect.cleandoc(text)
+
+        # Find first title and split on its position
+        match = self.titles_re.search(text)
+        if match:
+            desc_chunk = text[:match.start()]
+            meta_chunk = text[match.start():]
+        else:
+            desc_chunk = text
+            meta_chunk = ""
+
+        # Break description into short and long parts
+        parts = desc_chunk.split("\n", 1)
+        ret.short_description = parts[0] or None
+        if len(parts) > 1:
+            long_desc_chunk = parts[1] or ""
+            ret.blank_after_short_description = long_desc_chunk.startswith(
+                "\n"
+            )
+            ret.blank_after_long_description = long_desc_chunk.endswith("\n\n")
+            ret.long_description = long_desc_chunk.strip() or None
+
+        for match, nextmatch in _pairwise(self.titles_re.finditer(meta_chunk)):
+            title = next(g for g in match.groups() if g is not None)
+            factory = self.sections[title]
+
+            # section chunk starts after the header,
+            # ends at the start of the next header
+            start = match.end()
+            end = nextmatch.start() if nextmatch is not None else None
+            ret.meta.extend(factory.parse(meta_chunk[start:end]))
+
+        return ret
+
+
+def parse(text: str) -> Docstring:
+    """Parse the numpy-style docstring into its components.
+
+    :returns: parsed docstring
+    """
+    return NumpydocParser().parse(text)

--- a/docstring_parser/styles.py
+++ b/docstring_parser/styles.py
@@ -2,13 +2,15 @@
 
 import enum
 
-from . import google, rest
+from . import google, rest, numpydoc
 
 
 class Style(enum.Enum):
     rest = enum.auto()
     google = enum.auto()
+    numpydoc = enum.auto()
     auto = enum.auto()
 
 
-STYLES = {Style.rest: rest.parse, Style.google: google.parse}
+STYLES = {Style.rest: rest.parse, Style.google: google.parse,
+          Style.numpydoc: numpydoc.parse}

--- a/docstring_parser/tests/test_numpydoc.py
+++ b/docstring_parser/tests/test_numpydoc.py
@@ -1,0 +1,657 @@
+import typing as T
+
+import pytest
+from docstring_parser.numpydoc import parse
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("", None),
+        ("\n", None),
+        ("Short description", "Short description"),
+        ("\nShort description\n", "Short description"),
+        ("\n   Short description\n", "Short description"),
+    ],
+)
+def test_short_description(source: str, expected: str) -> None:
+    docstring = parse(source)
+    assert docstring.short_description == expected
+    assert docstring.long_description is None
+    assert docstring.meta == []
+
+
+@pytest.mark.parametrize(
+    "source, expected_short_desc, expected_long_desc, expected_blank",
+    [
+        (
+            "Short description\n\nLong description",
+            "Short description",
+            "Long description",
+            True,
+        ),
+        (
+            """
+            Short description
+
+            Long description
+            """,
+            "Short description",
+            "Long description",
+            True,
+        ),
+        (
+            """
+            Short description
+
+            Long description
+            Second line
+            """,
+            "Short description",
+            "Long description\nSecond line",
+            True,
+        ),
+        (
+            "Short description\nLong description",
+            "Short description",
+            "Long description",
+            False,
+        ),
+        (
+            """
+            Short description
+            Long description
+            """,
+            "Short description",
+            "Long description",
+            False,
+        ),
+        (
+            "\nShort description\nLong description\n",
+            "Short description",
+            "Long description",
+            False,
+        ),
+        (
+            """
+            Short description
+            Long description
+            Second line
+            """,
+            "Short description",
+            "Long description\nSecond line",
+            False,
+        ),
+    ],
+)
+def test_long_description(
+    source: str,
+    expected_short_desc: str,
+    expected_long_desc: str,
+    expected_blank: bool,
+) -> None:
+    docstring = parse(source)
+    assert docstring.short_description == expected_short_desc
+    assert docstring.long_description == expected_long_desc
+    assert docstring.blank_after_short_description == expected_blank
+    assert docstring.meta == []
+
+
+@pytest.mark.parametrize(
+    "source, expected_short_desc, expected_long_desc, "
+    "expected_blank_short_desc, expected_blank_long_desc",
+    [
+        (
+            """
+            Short description
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description",
+            None,
+            False,
+            False,
+        ),
+        (
+            """
+            Short description
+            Long description
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description",
+            "Long description",
+            False,
+            False,
+        ),
+        (
+            """
+            Short description
+            First line
+                Second line
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description",
+            "First line\n    Second line",
+            False,
+            False,
+        ),
+        (
+            """
+            Short description
+
+            First line
+                Second line
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description",
+            "First line\n    Second line",
+            True,
+            False,
+        ),
+        (
+            """
+            Short description
+
+            First line
+                Second line
+
+            Parameters
+            ----------
+            asd
+            """,
+            "Short description",
+            "First line\n    Second line",
+            True,
+            True,
+        ),
+        (
+            """
+            Parameters
+            ----------
+            asd
+            """,
+            None,
+            None,
+            False,
+            False,
+        ),
+    ],
+)
+def test_meta_newlines(
+    source: str,
+    expected_short_desc: T.Optional[str],
+    expected_long_desc: T.Optional[str],
+    expected_blank_short_desc: bool,
+    expected_blank_long_desc: bool,
+) -> None:
+    docstring = parse(source)
+    assert docstring.short_description == expected_short_desc
+    assert docstring.long_description == expected_long_desc
+    assert docstring.blank_after_short_description == expected_blank_short_desc
+    assert docstring.blank_after_long_description == expected_blank_long_desc
+    assert len(docstring.meta) == 1
+
+
+def test_meta_with_multiline_description() -> None:
+    docstring = parse(
+        """
+        Short description
+
+        Parameters
+        ----------
+        spam
+            asd
+            1
+                2
+            3
+        """
+    )
+    assert docstring.short_description == "Short description"
+    assert len(docstring.meta) == 1
+    assert docstring.meta[0].args == ["param", "spam"]
+    assert docstring.meta[0].arg_name == "spam"
+    assert docstring.meta[0].description == "asd\n1\n    2\n3"
+
+
+def test_default_args():
+    docstring = parse(
+        """
+        A sample function
+
+        A function the demonstrates docstrings
+
+        Parameters
+        ----------
+        arg1 : int
+            The firsty arg
+        arg2 : str
+            The second arg
+        arg3 : float, optional
+            The third arg. Default is 1.0.
+        arg4 : Optional[Dict[str, Any]], optional
+            The fourth arg. Defaults to None
+        arg5 : str, optional
+            The fifth arg. Default: DEFAULT_ARGS
+
+        Returns
+        -------
+        Mapping[str, Any]
+            The args packed in a mapping
+        """
+    )
+    assert docstring is not None
+    assert len(docstring.params) == 5
+
+    arg4 = docstring.params[3]
+    assert arg4.arg_name == "arg4"
+    assert arg4.is_optional
+    assert arg4.type_name == "Optional[Dict[str, Any]]"
+    assert arg4.default == "None"
+    assert arg4.description == "The fourth arg. Defaults to None"
+
+
+def test_multiple_meta() -> None:
+    docstring = parse(
+        """
+        Short description
+
+        Parameters
+        ----------
+        spam
+            asd
+            1
+                2
+            3
+
+        Raises
+        ------
+        bla
+            herp
+        yay
+            derp
+        """
+    )
+    assert docstring.short_description == "Short description"
+    assert len(docstring.meta) == 3
+    assert docstring.meta[0].args == ["param", "spam"]
+    assert docstring.meta[0].arg_name == "spam"
+    assert docstring.meta[0].description == "asd\n1\n    2\n3"
+    assert docstring.meta[1].args == ["raises", "bla"]
+    assert docstring.meta[1].type_name == "bla"
+    assert docstring.meta[1].description == "herp"
+    assert docstring.meta[2].args == ["raises", "yay"]
+    assert docstring.meta[2].type_name == "yay"
+    assert docstring.meta[2].description == "derp"
+
+
+def test_params() -> None:
+    docstring = parse("Short description")
+    assert len(docstring.params) == 0
+
+    docstring = parse(
+        """
+        Short description
+
+        Parameters
+        ----------
+        name
+            description 1
+        priority : int
+            description 2
+        sender : str, optional
+            description 3
+        ratio : Optional[float], optional
+            description 4
+        """
+    )
+    assert len(docstring.params) == 4
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == "description 1"
+    assert not docstring.params[0].is_optional
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+    assert not docstring.params[1].is_optional
+    assert docstring.params[2].arg_name == "sender"
+    assert docstring.params[2].type_name == "str"
+    assert docstring.params[2].description == "description 3"
+    assert docstring.params[2].is_optional
+    assert docstring.params[3].arg_name == "ratio"
+    assert docstring.params[3].type_name == "Optional[float]"
+    assert docstring.params[3].description == "description 4"
+    assert docstring.params[3].is_optional
+
+    docstring = parse(
+        """
+        Short description
+
+        Parameters
+        ----------
+        name
+            description 1
+            with multi-line text
+        priority : int
+            description 2
+        """
+    )
+    assert len(docstring.params) == 2
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == (
+        "description 1\n" "with multi-line text"
+    )
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+
+
+def test_attributes() -> None:
+    docstring = parse("Short description")
+    assert len(docstring.params) == 0
+
+    docstring = parse(
+        """
+        Short description
+
+        Attributes
+        ----------
+        name
+            description 1
+        priority : int
+            description 2
+        sender : str, optional
+            description 3
+        ratio : Optional[float], optional
+            description 4
+        """
+    )
+    assert len(docstring.params) == 4
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == "description 1"
+    assert not docstring.params[0].is_optional
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+    assert not docstring.params[1].is_optional
+    assert docstring.params[2].arg_name == "sender"
+    assert docstring.params[2].type_name == "str"
+    assert docstring.params[2].description == "description 3"
+    assert docstring.params[2].is_optional
+    assert docstring.params[3].arg_name == "ratio"
+    assert docstring.params[3].type_name == "Optional[float]"
+    assert docstring.params[3].description == "description 4"
+    assert docstring.params[3].is_optional
+
+    docstring = parse(
+        """
+        Short description
+
+        Attributes
+        ----------
+        name
+            description 1
+            with multi-line text
+        priority : int
+            description 2
+        """
+    )
+    assert len(docstring.params) == 2
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == (
+        "description 1\n" "with multi-line text"
+    )
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+
+
+def test_other_params() -> None:
+    docstring = parse(
+        """
+        Short description
+        Other Parameters
+        ----------------
+        only_seldom_used_keywords : type, optional
+            Explanation
+        common_parameters_listed_above : type, optional
+            Explanation
+        """
+    )
+    assert len(docstring.meta) == 2
+    assert docstring.meta[0].args == ['other_param',
+                                      'only_seldom_used_keywords']
+    assert docstring.meta[0].arg_name == 'only_seldom_used_keywords'
+    assert docstring.meta[0].type_name == "type"
+    assert docstring.meta[0].is_optional
+    assert docstring.meta[0].description == "Explanation"
+
+    assert docstring.meta[1].args == ['other_param',
+                                      'common_parameters_listed_above']
+
+
+def test_yields() -> None:
+    docstring = parse(
+        """
+        Short description
+        Yields
+        ------
+        int
+            description
+        """
+    )
+    assert len(docstring.meta) == 1
+    assert docstring.meta[0].args == ['yields']
+    assert docstring.meta[0].type_name == "int"
+    assert docstring.meta[0].description == "description"
+    assert docstring.meta[0].return_name is None
+    assert docstring.meta[0].is_generator
+
+
+def test_returns() -> None:
+    docstring = parse(
+        """
+        Short description
+        """
+    )
+    assert docstring.returns is None
+
+    docstring = parse(
+        """
+        Short description
+        Returns
+        -------
+        type
+        """
+    )
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == 'type'
+    assert docstring.returns.description is None
+
+    docstring = parse(
+        """
+        Short description
+        Returns
+        -------
+        int
+            description
+        """
+    )
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "int"
+    assert docstring.returns.description == "description"
+
+    docstring = parse(
+        """
+        Returns
+        -------
+        Optional[Mapping[str, List[int]]]
+            A description: with a colon
+        """
+    )
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "Optional[Mapping[str, List[int]]]"
+    assert docstring.returns.description == "A description: with a colon"
+
+    docstring = parse(
+        """
+        Short description
+        Returns
+        -------
+        int
+            description
+            with much text
+
+            even some spacing
+        """
+    )
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "int"
+    assert docstring.returns.description == (
+        "description\n" "with much text\n\n" "even some spacing"
+    )
+
+
+def test_raises() -> None:
+    docstring = parse(
+        """
+        Short description
+        """
+    )
+    assert len(docstring.raises) == 0
+
+    docstring = parse(
+        """
+        Short description
+        Raises
+        ------
+        ValueError
+            description
+        """
+    )
+    assert len(docstring.raises) == 1
+    assert docstring.raises[0].type_name == "ValueError"
+    assert docstring.raises[0].description == "description"
+
+
+def test_warns() -> None:
+    docstring = parse(
+        """
+        Short description
+        Warns
+        -----
+        UserWarning
+            description
+        """
+    )
+    assert len(docstring.meta) == 1
+    assert docstring.meta[0].type_name == "UserWarning"
+    assert docstring.meta[0].description == "description"
+
+
+def test_simple_sections() -> None:
+    docstring = parse(
+        """
+        Short description
+
+        See Also
+        --------
+        something : some thing you can also see
+        actually, anything can go in this section
+
+        Warnings
+        --------
+        Here be dragons
+
+        Notes
+        -----
+        None of this is real
+
+        References
+        ----------
+        Cite the relevant literature, e.g. [1]_.  You may also cite these
+        references in the notes section above.
+
+        .. [1] O. McNoleg, "The integration of GIS, remote sensing,
+           expert systems and adaptive co-kriging for environmental habitat
+           modelling of the Highland Haggis using object-oriented, fuzzy-logic
+           and neural-network techniques," Computers & Geosciences, vol. 22,
+           pp. 585-588, 1996.
+        """
+    )
+    assert len(docstring.meta) == 4
+    assert docstring.meta[0].args == ['see_also']
+    assert docstring.meta[0].description == (
+        "something : some thing you can also see\n"
+        "actually, anything can go in this section"
+    )
+
+    assert docstring.meta[1].args == ['warnings']
+    assert docstring.meta[1].description == "Here be dragons"
+
+    assert docstring.meta[2].args == ['notes']
+    assert docstring.meta[2].description == "None of this is real"
+
+    assert docstring.meta[3].args == ['references']
+
+
+def test_examples() -> None:
+    docstring = parse(
+        """
+        Short description
+        Examples
+        --------
+        long example
+
+        more here
+        """
+    )
+    assert len(docstring.meta) == 1
+    assert docstring.meta[0].description == "long example\n\nmore here"
+
+
+@pytest.mark.parametrize(
+    "source, expected_depr_version, expected_depr_desc",
+    [
+        (
+            "Short description\n\n.. deprecated:: 1.6.0\n    This is busted!",
+            "1.6.0",
+            "This is busted!"
+        ),
+        (
+            ("Short description\n\n"
+             ".. deprecated:: 1.6.0\n"
+             "    This description has\n"
+             "    multiple lines!"),
+            "1.6.0",
+            "This description has\nmultiple lines!"
+        ),
+        (
+            "Short description\n\n.. deprecated:: 1.6.0",
+            "1.6.0",
+            None
+        ),
+        (
+            "Short description\n\n.. deprecated::\n    No version!",
+            None,
+            "No version!"
+        )
+    ]
+)
+def test_deprecation(source: str,
+                     expected_depr_version: T.Optional[str],
+                     expected_depr_desc: T.Optional[str]) -> None:
+    docstring = parse(source)
+
+    assert docstring.deprecation is not None
+    assert docstring.deprecation.version == expected_depr_version
+    assert docstring.deprecation.description == expected_depr_desc

--- a/docstring_parser/tests/test_parser.py
+++ b/docstring_parser/tests/test_parser.py
@@ -87,3 +87,76 @@ def test_google() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "tuple"
     assert docstring.returns.description == "ret desc"
+
+
+def test_numpydoc() -> None:
+    docstring = parse(
+        """Short description
+
+        Long description
+
+        Causing people to indent:
+
+            A lot sometimes
+
+        Parameters
+        ----------
+        spam
+            spam desc
+        bla : int
+            bla desc
+        yay : str
+
+        Raises
+        ------
+        ValueError
+            exc desc
+
+        Other Parameters
+        ----------------
+        this_guy : int, optional
+            you know him
+
+        Returns
+        -------
+        tuple
+            ret desc
+
+        See Also
+        --------
+        multiple lines...
+        something else?
+
+        Warnings
+        --------
+        multiple lines...
+        none of this is real!
+        """
+    )
+    assert docstring.short_description == "Short description"
+    assert docstring.long_description == (
+        "Long description\n\n"
+        "Causing people to indent:\n\n"
+        "    A lot sometimes"
+    )
+    assert len(docstring.params) == 4
+    assert docstring.params[0].arg_name == "spam"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == "spam desc"
+    assert docstring.params[1].arg_name == "bla"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "bla desc"
+    assert docstring.params[2].arg_name == "yay"
+    assert docstring.params[2].type_name == "str"
+    assert docstring.params[2].description is None
+    assert docstring.params[3].arg_name == "this_guy"
+    assert docstring.params[3].type_name == "int"
+    assert docstring.params[3].is_optional
+    assert docstring.params[3].description == "you know him"
+
+    assert len(docstring.raises) == 1
+    assert docstring.raises[0].type_name == "ValueError"
+    assert docstring.raises[0].description == "exc desc"
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "tuple"
+    assert docstring.returns.description == "ret desc"


### PR DESCRIPTION
Related to #3. Looks to me like that never got resolved for lack of a nice way to get it done without adding a huge `numpydoc` dependency.

This patch rolls our own numpydoc-style parsing without adding any dependencies, using a regex strategy like the google and ReST parsers.

I wanted to use this so I knocked this out pretty quick and I can't promise 100% accuracy.

- Tests for numpydoc parser
- Implementation of numpydoc parser
- DocstringDeprecation metadata type
- Documentation for numpydoc-style parser
- Added numpydoc to supported styles in README