### PR TITLE
Create py.typed

### DIFF
--- a/docstring_parser/py.typed
+++ b/docstring_parser/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,6 @@ classifiers =
 python_requires = ~=3.5
 package_dir = docstring_parser=docstring_parser
 packages = find:
+
+[options.package_data]
+docstring_parser = py.typed


### PR DESCRIPTION
This enables consumers of docstring_parser to use the typing validation that is already included.

See https://www.python.org/dev/peps/pep-0561/  for info