### PR TITLE
Add API doc generation as part of the github workflow

### DIFF
--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install requirements for documentation generation
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install docutils pydoctor
+        python -m pip install docutils git+https://github.com/twisted/pydoctor.git
 
     - name: Generate API documentation with pydoctor
       run: |

--- a/.github/workflows/apidocs.yml
+++ b/.github/workflows/apidocs.yml
@@ -1,0 +1,41 @@
+name: apidocs
+on:
+- push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install requirements for documentation generation
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install docutils pydoctor
+
+    - name: Generate API documentation with pydoctor
+      run: |
+
+        # Run pydoctor build
+        pydoctor \
+            --project-name=docstring_parser \
+            --project-url=https://github.com/$GITHUB_REPOSITORY \
+            --html-viewsource-base=https://github.com/$GITHUB_REPOSITORY/tree/$GITHUB_SHA \
+            --make-html \
+            --html-output=./apidocs \
+            --project-base-dir="$(pwd)" \
+            --docformat=restructuredtext \
+            --intersphinx=https://docs.python.org/3/objects.inv \
+            ./docstring_parser
+
+    - name: Push API documentation to Github Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./apidocs
+        commit_message: "Generate API documentation"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Example usage:
 'ValueError'
 ```
 
+Read [API Documentation](https://rr-.github.io/docstring_parser/).
+
 # Contributing
 
 This project uses [Black](https://github.com/psf/black) with `-l79` setting as

--- a/docstring_parser/numpydoc.py
+++ b/docstring_parser/numpydoc.py
@@ -1,6 +1,6 @@
 """Numpydoc-style docstring parsing.
 
-.. seealso:: https://numpydoc.readthedocs.io/en/latest/format.html
+:see: https://numpydoc.readthedocs.io/en/latest/format.html
 """
 
 import inspect


### PR DESCRIPTION
See demo here: https://tristanlatr.github.io/docstring_parser/

Hope this helps!

Edit: I realize that the `docstring_parser.parser.parse()` function did not got re-exported correctly to `docstring_parser` module and also the `Style` class do not appear :/