### PR TITLE
Allows Docstring to return a list of DocstringReturns to better work with numpydoc

### DIFF
--- a/docstring_parser/common.py
+++ b/docstring_parser/common.py
@@ -151,6 +151,12 @@ class Docstring:
         return None
 
     @property
+    def many_returns(self) -> T.List[DocstringReturns]:
+        return [
+            item for item in self.meta if isinstance(item, DocstringReturns)
+        ]
+
+    @property
     def deprecation(self) -> T.Optional[DocstringDeprecated]:
         for item in self.meta:
             if isinstance(item, DocstringDeprecated):

--- a/docstring_parser/numpydoc.py
+++ b/docstring_parser/numpydoc.py
@@ -172,7 +172,7 @@ class RaisesSection(_KVSection):
 
 
 class ReturnsSection(_KVSection):
-    """Parser for numpydoc raises sections.
+    """Parser for numpydoc returns sections.
 
     E.g. any section that looks like this:
         return_name : type

--- a/docstring_parser/tests/test_google.py
+++ b/docstring_parser/tests/test_google.py
@@ -476,6 +476,8 @@ def test_returns() -> None:
         """
     )
     assert docstring.returns is None
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 0
 
     docstring = parse(
         """
@@ -487,6 +489,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name is None
     assert docstring.returns.description == "description"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -498,6 +503,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name is None
     assert docstring.returns.description == "description with: a colon!"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -509,6 +517,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "int"
     assert docstring.returns.description == "description"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -519,6 +530,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "Optional[Mapping[str, List[int]]]"
     assert docstring.returns.description == "A description: with a colon"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -530,6 +544,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "int"
     assert docstring.returns.description == "description"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -546,6 +563,9 @@ def test_returns() -> None:
     assert docstring.returns.description == (
         "description\n" "with much text\n\n" "even some spacing"
     )
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
 
 def test_raises() -> None:

--- a/docstring_parser/tests/test_numpydoc.py
+++ b/docstring_parser/tests/test_numpydoc.py
@@ -468,6 +468,8 @@ def test_returns() -> None:
         """
     )
     assert docstring.returns is None
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 0
 
     docstring = parse(
         """
@@ -480,6 +482,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "type"
     assert docstring.returns.description is None
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -493,6 +498,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "int"
     assert docstring.returns.description == "description"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -505,6 +513,9 @@ def test_returns() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "Optional[Mapping[str, List[int]]]"
     assert docstring.returns.description == "A description: with a colon"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -523,6 +534,9 @@ def test_returns() -> None:
     assert docstring.returns.description == (
         "description\n" "with much text\n\n" "even some spacing"
     )
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -535,6 +549,9 @@ def test_returns() -> None:
             description for b
         """
     )
+    assert docstring.returns is not None
+    assert docstring.returns.type_name == "int"
+    assert docstring.returns.description == ("description for a")
     assert docstring.many_returns is not None
     assert len(docstring.many_returns) == 2
     assert docstring.many_returns[0].type_name == "int"

--- a/docstring_parser/tests/test_numpydoc.py
+++ b/docstring_parser/tests/test_numpydoc.py
@@ -524,6 +524,26 @@ def test_returns() -> None:
         "description\n" "with much text\n\n" "even some spacing"
     )
 
+    docstring = parse(
+        """
+        Short description
+        Returns
+        -------
+        a : int
+            description for a
+        b : str
+            description for b
+        """
+    )
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 2
+    assert docstring.many_returns[0].type_name == "int"
+    assert docstring.many_returns[0].description == "description for a"
+    assert docstring.many_returns[0].return_name == "a"
+    assert docstring.many_returns[1].type_name == "str"
+    assert docstring.many_returns[1].description == "description for b"
+    assert docstring.many_returns[1].return_name == "b"
+
 
 def test_raises() -> None:
     docstring = parse(

--- a/docstring_parser/tests/test_parser.py
+++ b/docstring_parser/tests/test_parser.py
@@ -44,6 +44,9 @@ def test_rest() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "tuple"
     assert docstring.returns.description == "ret desc"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
 
 def test_google() -> None:
@@ -92,6 +95,9 @@ def test_google() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "tuple"
     assert docstring.returns.description == "ret desc"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
 
 def test_numpydoc() -> None:
@@ -167,3 +173,6 @@ def test_numpydoc() -> None:
     assert docstring.returns is not None
     assert docstring.returns.type_name == "tuple"
     assert docstring.returns.description == "ret desc"
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns

--- a/docstring_parser/tests/test_rest.py
+++ b/docstring_parser/tests/test_rest.py
@@ -298,6 +298,8 @@ def test_returns() -> None:
         """
     )
     assert docstring.returns is None
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 0
 
     docstring = parse(
         """
@@ -309,6 +311,9 @@ def test_returns() -> None:
     assert docstring.returns.type_name is None
     assert docstring.returns.description == "description"
     assert not docstring.returns.is_generator
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -320,6 +325,9 @@ def test_returns() -> None:
     assert docstring.returns.type_name == "int"
     assert docstring.returns.description == "description"
     assert not docstring.returns.is_generator
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
 
 def test_yields() -> None:
@@ -329,6 +337,8 @@ def test_yields() -> None:
         """
     )
     assert docstring.returns is None
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 0
 
     docstring = parse(
         """
@@ -340,6 +350,9 @@ def test_yields() -> None:
     assert docstring.returns.type_name is None
     assert docstring.returns.description == "description"
     assert docstring.returns.is_generator
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
     docstring = parse(
         """
@@ -351,6 +364,9 @@ def test_yields() -> None:
     assert docstring.returns.type_name == "int"
     assert docstring.returns.description == "description"
     assert docstring.returns.is_generator
+    assert docstring.many_returns is not None
+    assert len(docstring.many_returns) == 1
+    assert docstring.many_returns[0] == docstring.returns
 
 
 def test_raises() -> None:


### PR DESCRIPTION
PR for #33 
[Numpydoc supports multiple return values in the return section. ](https://numpydoc.readthedocs.io/en/latest/format.html#returns) Here's an example:
```
Returns
-------
err_code : int
    Non-zero value indicates error code, or zero on success.
err_msg : str or None
    Human readable error message, or None on success.
```
This PR attempts to add support for multiple return values, since the library only supports a single return value at the moment. 
The ideal solution would be updating the existing `Docstring.returns` to return `T.List[DocstringReturns]` instead of `T.Optional[DocstringReturns]`. This is a breaking change, but it's more consistent with how params work. The alternative solution is adding a new property that returns `T.List[DocstringReturns]`, which is what's in this draft PR. I also added a few lines of unit test to showcase the use case. This is only a draft PR. Depending on how the maintainers feel about the backwards compatibility, things may go very differently.