### PR TITLE
Improve epydoc logic and add unparse functionality

### DIFF
--- a/docstring_parser/__init__.py
+++ b/docstring_parser/__init__.py
@@ -11,10 +11,11 @@ from .common import (
 from .common import DocstringStyle  # backwards compatibility
 from .common import DocstringStyle as Style
 from .common import ParseError
-from .parser import parse
+from .parser import parse, unparse
 
 __all__ = [
     "parse",
+    "unparse",
     "ParseError",
     "Docstring",
     "DocstringMeta",

--- a/docstring_parser/common.py
+++ b/docstring_parser/common.py
@@ -31,6 +31,14 @@ class DocstringStyle(enum.Enum):
     auto = 255
 
 
+class RenderingStyle(enum.Enum):
+    """Rendering style when unparsing parsed docstrings."""
+
+    compact = 1
+    clean = 2
+    expanded = 3
+
+
 class DocstringMeta:
     """Docstring meta information.
 
@@ -40,7 +48,9 @@ class DocstringMeta:
         :raises ValueError: if something happens
     """
 
-    def __init__(self, args: T.List[str], description: str) -> None:
+    def __init__(
+        self, args: T.List[str], description: T.Optional[str]
+    ) -> None:
         """Initialize self.
 
         :param args: list of arguments. The exact content of this variable is

--- a/docstring_parser/epydoc.py
+++ b/docstring_parser/epydoc.py
@@ -14,6 +14,7 @@ from .common import (
     DocstringReturns,
     DocstringStyle,
     ParseError,
+    RenderingStyle,
 )
 
 
@@ -189,5 +190,78 @@ def parse(text: str) -> Docstring:
 
         ret.meta.append(r)
 
-
     return ret
+
+
+def unparse(
+    docstring: Docstring,
+    rendering_style: RenderingStyle = RenderingStyle.compact,
+    indent: str = "    ",
+) -> str:
+    """Render a parsed docstring into docstring text.
+
+    :param docstring: parsed docstring representation
+    :param rendering_style: the style to render unparsed docstrings
+    :param indent: the characters used as indentation in the docstring string
+    :returns: docstring text
+    """
+
+    def process_desc(desc: T.Optional[str], is_type: bool) -> str:
+        if not desc:
+            return ""
+        elif (rendering_style == RenderingStyle.expanded) or (
+            rendering_style == RenderingStyle.clean and not is_type
+        ):
+            (first, *rest) = desc.splitlines()
+            return "\n".join(
+                ["\n" + indent + first] + [indent + line for line in rest]
+            )
+        else:
+            (first, *rest) = desc.splitlines()
+            return "\n".join([" " + first] + [indent + line for line in rest])
+
+    parts: T.List[str] = []
+    if docstring.short_description:
+        parts.append(docstring.short_description)
+    if docstring.blank_after_short_description:
+        parts.append("")
+    if docstring.long_description:
+        parts.append(docstring.long_description)
+    if docstring.blank_after_long_description:
+        parts.append("")
+
+    for meta in docstring.meta:
+        if isinstance(meta, DocstringParam):
+            if meta.type_name:
+                type_name = (
+                    f"{meta.type_name}?"
+                    if meta.is_optional
+                    else meta.type_name
+                )
+                text = f"@type {meta.arg_name}:"
+                text += process_desc(type_name, True)
+                parts.append(text)
+            text = f"@param {meta.arg_name}:" + process_desc(
+                meta.description, False
+            )
+            parts.append(text)
+        elif isinstance(meta, DocstringReturns):
+            (arg_key, type_key) = (
+                ("yield", "ytype")
+                if meta.is_generator
+                else ("return", "rtype")
+            )
+            if meta.type_name:
+                text = f"@{type_key}:" + process_desc(meta.type_name, True)
+                parts.append(text)
+            text = f"@{arg_key}:" + process_desc(meta.description, False)
+            parts.append(text)
+        elif isinstance(meta, DocstringRaises):
+            text = f"@raise {meta.type_name}:" if meta.type_name else "@raise:"
+            text += process_desc(meta.description, False)
+            parts.append(text)
+        else:
+            text = f'@{" ".join(meta.args)}:'
+            text += process_desc(meta.description, False)
+            parts.append(text)
+    return "\n".join(parts)

--- a/docstring_parser/google.py
+++ b/docstring_parser/google.py
@@ -18,6 +18,7 @@ from .common import (
     DocstringReturns,
     DocstringStyle,
     ParseError,
+    RenderingStyle,
 )
 
 
@@ -284,3 +285,118 @@ def parse(text: str) -> Docstring:
     :returns: parsed docstring
     """
     return GoogleParser().parse(text)
+
+
+def unparse(
+    docstring: Docstring,
+    rendering_style: RenderingStyle = RenderingStyle.compact,
+    indent: str = "    ",
+) -> str:
+    """Render a parsed docstring into docstring text.
+
+    :param docstring: parsed docstring representation
+    :param rendering_style: the style to render unparsed docstrings
+    :param indent: the characters used as indentation in the docstring string
+    :returns: docstring text
+    """
+
+    def process_one(
+        one: T.Union[DocstringParam, DocstringReturns, DocstringRaises]
+    ):
+        head = ""
+
+        if isinstance(one, DocstringParam):
+            head += one.arg_name or ""
+        elif isinstance(one, DocstringReturns):
+            head += one.return_name or ""
+
+        if isinstance(one, DocstringParam) and one.is_optional:
+            optional = (
+                "?"
+                if rendering_style == RenderingStyle.compact
+                else ", optional"
+            )
+        else:
+            optional = ""
+
+        if one.type_name and head:
+            head += f" ({one.type_name}{optional}):"
+        elif one.type_name:
+            head += f"{one.type_name}{optional}:"
+        else:
+            head += ":"
+        head = indent + head
+
+        if one.description and rendering_style == RenderingStyle.expanded:
+            body = f"\n{indent}{indent}".join(
+                [head] + one.description.splitlines()
+            )
+            parts.append(body)
+        elif one.description:
+            (first, *rest) = one.description.splitlines()
+            body = f"\n{indent}{indent}".join([head + " " + first] + rest)
+            parts.append(body)
+        else:
+            parts.append(head)
+
+    def process_sect(name: str, args: T.List[T.Any]):
+        if args:
+            parts.append(name)
+            for arg in args:
+                process_one(arg)
+            parts.append("")
+
+    parts: T.List[str] = []
+    if docstring.short_description:
+        parts.append(docstring.short_description)
+    if docstring.blank_after_short_description:
+        parts.append("")
+
+    if docstring.long_description:
+        parts.append(docstring.long_description)
+    if docstring.blank_after_long_description:
+        parts.append("")
+
+    process_sect(
+        "Args:", [p for p in docstring.params or [] if p.args[0] == "param"]
+    )
+
+    process_sect(
+        "Attributes:",
+        [p for p in docstring.params or [] if p.args[0] == "attribute"],
+    )
+
+    process_sect(
+        "Returns:",
+        [p for p in docstring.many_returns or [] if not p.is_generator],
+    )
+
+    process_sect(
+        "Yields:", [p for p in docstring.many_returns or [] if p.is_generator]
+    )
+
+    process_sect("Raises:", [p for p in docstring.raises or []])
+
+    if docstring.returns and not docstring.many_returns:
+        ret = docstring.returns
+        parts.append("Yields:" if ret else "Returns:")
+        parts.append("-" * len(parts[-1]))
+        process_one(ret)
+
+    for meta in docstring.meta:
+        if isinstance(
+            meta, (DocstringParam, DocstringReturns, DocstringRaises)
+        ):
+            continue  # Already handled
+        parts.append(meta.args[0].replace("_", "").title() + ":")
+        if meta.description:
+            lines = [indent + l for l in meta.description.splitlines()]
+            parts.append("\n".join(lines))
+        parts.append("")
+
+    if parts and not parts[-1]:
+        return "\n".join(
+            parts[:-1]
+        )  # Don't end the docstring in an empty line
+    else:
+        return "\n".join(parts)

--- a/docstring_parser/numpydoc.py
+++ b/docstring_parser/numpydoc.py
@@ -3,6 +3,7 @@
 .. seealso:: https://numpydoc.readthedocs.io/en/latest/format.html
 """
 
+from email import message_from_binary_file
 import inspect
 import itertools
 import re
@@ -16,6 +17,7 @@ from .common import (
     DocstringRaises,
     DocstringReturns,
     DocstringStyle,
+    RenderingStyle,
 )
 
 
@@ -330,3 +332,136 @@ def parse(text: str) -> Docstring:
     :returns: parsed docstring
     """
     return NumpydocParser().parse(text)
+
+
+def unparse(
+    docstring: Docstring,
+    rendering_style: RenderingStyle = RenderingStyle.compact,
+    indent: str = "    ",
+) -> str:
+    """Render a parsed docstring into docstring text.
+
+    :param docstring: parsed docstring representation
+    :param rendering_style: the style to render unparsed docstrings
+    :param indent: the characters used as indentation in the docstring string
+    :returns: docstring text
+    """
+
+    def process_one(
+        one: T.Union[DocstringParam, DocstringReturns, DocstringRaises]
+    ):
+        if isinstance(one, DocstringParam):
+            head = one.arg_name
+        elif isinstance(one, DocstringReturns):
+            head = one.return_name
+        else:
+            head = None
+
+        if one.type_name and head:
+            head += f" : {one.type_name}"
+        elif one.type_name:
+            head = one.type_name
+        elif not head:
+            head = ""
+
+        if isinstance(one, DocstringParam) and one.is_optional:
+            head += ", optional"
+
+        if one.description:
+            body = f"\n{indent}".join([head] + one.description.splitlines())
+            parts.append(body)
+        else:
+            parts.append(head)
+
+    def process_sect(name: str, args: T.List[T.Any]):
+        if args:
+            parts.append("")
+            parts.append(name)
+            parts.append("-" * len(parts[-1]))
+            for arg in args:
+                process_one(arg)
+
+    parts: T.List[str] = []
+    if docstring.short_description:
+        parts.append(docstring.short_description)
+    if docstring.blank_after_short_description:
+        parts.append("")
+
+    if docstring.deprecation:
+        first = ".. deprecated::"
+        if docstring.deprecation.version:
+            first += f" {docstring.deprecation.version}"
+        if docstring.deprecation.description:
+            rest = docstring.deprecation.description.splitlines()
+        else:
+            rest = []
+        sep = f"\n{indent}"
+        parts.append(sep.join([first] + rest))
+
+    if docstring.long_description:
+        parts.append(docstring.long_description)
+    if docstring.blank_after_long_description:
+        parts.append("")
+
+    process_sect(
+        "Parameters",
+        [p for p in docstring.params or [] if p.args[0] == "param"],
+    )
+
+    process_sect(
+        "Attributes",
+        [p for p in docstring.params or [] if p.args[0] == "attribute"],
+    )
+
+    process_sect(
+        "Returns",
+        [p for p in docstring.many_returns or [] if not p.is_generator],
+    )
+
+    process_sect(
+        "Yields", [p for p in docstring.many_returns or [] if p.is_generator]
+    )
+
+    if docstring.returns and not docstring.many_returns:
+        ret = docstring.returns
+        parts.append("Yields" if ret else "Returns")
+        parts.append("-" * len(parts[-1]))
+        process_one(ret)
+
+    process_sect(
+        "Receives",
+        [p for p in docstring.params or [] if p.args[0] == "receives"],
+    )
+
+    process_sect(
+        "Other Parameters",
+        [p for p in docstring.params or [] if p.args[0] == "other_param"],
+    )
+
+    process_sect(
+        "Raises", [p for p in docstring.raises or [] if p.args[0] == "raises"]
+    )
+
+    process_sect(
+        "Warns", [p for p in docstring.raises or [] if p.args[0] == "warns"]
+    )
+
+    for meta in docstring.meta:
+        if isinstance(
+            meta,
+            (
+                DocstringDeprecated,
+                DocstringParam,
+                DocstringReturns,
+                DocstringRaises,
+            ),
+        ):
+            continue  # Already handled
+        parts.append("")
+        parts.append(meta.args[0].replace("_", "").title())
+        parts.append("-" * len(meta.args[0]))
+
+        if meta.description:
+            parts.append(meta.description)
+
+    return "\n".join(parts)

--- a/docstring_parser/parser.py
+++ b/docstring_parser/parser.py
@@ -1,13 +1,18 @@
 """The main parsing routine."""
 
 from docstring_parser import epydoc, google, numpydoc, rest
-from docstring_parser.common import Docstring, DocstringStyle, ParseError
+from docstring_parser.common import (
+    Docstring,
+    DocstringStyle,
+    ParseError,
+    RenderingStyle,
+)
 
 STYLES = {
-    DocstringStyle.rest: rest.parse,
-    DocstringStyle.google: google.parse,
-    DocstringStyle.numpydoc: numpydoc.parse,
-    DocstringStyle.epydoc: epydoc.parse,
+    DocstringStyle.rest: rest,
+    DocstringStyle.google: google,
+    DocstringStyle.numpydoc: numpydoc,
+    DocstringStyle.epydoc: epydoc,
 }
 
 
@@ -19,12 +24,12 @@ def parse(text: str, style: DocstringStyle = DocstringStyle.auto) -> Docstring:
     :returns: parsed docstring representation
     """
     if style != DocstringStyle.auto:
-        return STYLES[style](text)
+        return STYLES[style].parse(text)
 
     rets = []
-    for parse_ in STYLES.values():
+    for module in STYLES.values():
         try:
-            rets.append(parse_(text))
+            rets.append(module.parse(text))
         except ParseError as e:
             exc = e
 
@@ -32,3 +37,26 @@ def parse(text: str, style: DocstringStyle = DocstringStyle.auto) -> Docstring:
         raise exc
 
     return sorted(rets, key=lambda d: len(d.meta), reverse=True)[0]
+
+
+def unparse(
+    docstring: Docstring,
+    style: DocstringStyle = DocstringStyle.auto,
+    rendering_style: RenderingStyle = RenderingStyle.compact,
+    indent: str = "    ",
+) -> str:
+    """Render a parsed docstring into docstring text.
+
+    :param docstring: parsed docstring representation
+    :param style: docstring style to render (default renders style of `docstring`)
+    :param indent: the characters used as indentation in the docstring string
+    :returns: docstring text
+    """
+    if style != DocstringStyle.auto:
+        return STYLES[style].unparse(
+            docstring, rendering_style=rendering_style, indent=indent
+        )
+    else:
+        return STYLES[docstring.style].unparse(
+            docstring, rendering_style=rendering_style, indent=indent
+        )

--- a/docstring_parser/rest.py
+++ b/docstring_parser/rest.py
@@ -18,6 +18,7 @@ from .common import (
     DocstringReturns,
     DocstringStyle,
     ParseError,
+    RenderingStyle,
 )
 
 
@@ -72,7 +73,7 @@ def _build_meta(args: T.List[str], desc: str) -> DocstringMeta:
 
     if key in DEPRECATION_KEYWORDS:
         match = re.search(
-            "^(?P<version>v?((?:\d+)(?:\.[0-9a-z\.]+))) (?P<desc>.+)",
+            r"^(?P<version>v?((?:\d+)(?:\.[0-9a-z\.]+))) (?P<desc>.+)",
             desc,
             flags=re.I,
         )
@@ -150,3 +151,69 @@ def parse(text: str) -> Docstring:
         ret.meta.append(_build_meta(args, desc))
 
     return ret
+
+
+def unparse(
+    docstring: Docstring,
+    rendering_style: RenderingStyle = RenderingStyle.compact,
+    indent: str = "    ",
+) -> str:
+    """Render a parsed docstring into docstring text.
+
+    :param docstring: parsed docstring representation
+    :param rendering_style: the style to render unparsed docstrings
+    :param indent: the characters used as indentation in the docstring string
+    :returns: docstring text
+    """
+
+    def process_desc(desc: T.Optional[str]) -> str:
+        if not desc:
+            return ""
+        elif rendering_style == RenderingStyle.clean:
+            (first, *rest) = desc.splitlines()
+            return "\n".join([" " + first] + [indent + line for line in rest])
+        elif rendering_style == RenderingStyle.expanded:
+            (first, *rest) = desc.splitlines()
+            return "\n".join(
+                ["\n" + indent + first] + [indent + line for line in rest]
+            )
+        else:
+            return " " + desc
+
+    parts: T.List[str] = []
+    if docstring.short_description:
+        parts.append(docstring.short_description)
+    if docstring.blank_after_short_description:
+        parts.append("")
+    if docstring.long_description:
+        parts.append(docstring.long_description)
+    if docstring.blank_after_long_description:
+        parts.append("")
+
+    for meta in docstring.meta:
+        if isinstance(meta, DocstringParam):
+            if meta.type_name:
+                type_text = (
+                    f" {meta.type_name}? "
+                    if meta.is_optional
+                    else f" {meta.type_name} "
+                )
+            else:
+                type_text = " "
+            text = f":param{type_text}{meta.arg_name}:"
+            text += process_desc(meta.description)
+            parts.append(text)
+        elif isinstance(meta, DocstringReturns):
+            type_text = f" {meta.type_name} " if meta.type_name else ""
+            key = "yields" if meta.is_generator else "returns"
+            text = f":{key}{type_text}:"
+            text += process_desc(meta.description)
+            parts.append(text)
+        elif isinstance(meta, DocstringRaises):
+            type_text = f" {meta.type_name} " if meta.type_name else ""
+            text = f"@raises{type_text}:" + process_desc(meta.description)
+            parts.append(text)
+        else:
+            text = f'@{" ".join(meta.args)}:' + process_desc(meta.description)
+            parts.append(text)
+    return "\n".join(parts)

--- a/docstring_parser/tests/test_numpydoc.py
+++ b/docstring_parser/tests/test_numpydoc.py
@@ -1,7 +1,9 @@
 import typing as T
 
 import pytest
-from docstring_parser.numpydoc import parse
+
+from docstring_parser.common import RenderingStyle
+from docstring_parser.numpydoc import parse, unparse
 
 
 @pytest.mark.parametrize(
@@ -696,3 +698,184 @@ def test_deprecation(
     assert docstring.deprecation is not None
     assert docstring.deprecation.version == expected_depr_version
     assert docstring.deprecation.description == expected_depr_desc
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("", ""),
+        ("\n", ""),
+        ("Short description", "Short description"),
+        ("\nShort description\n", "Short description"),
+        ("\n   Short description\n", "Short description"),
+        (
+            "Short description\n\nLong description",
+            "Short description\n\nLong description",
+        ),
+        (
+            """
+            Short description
+
+            Long description
+            """,
+            "Short description\n\nLong description",
+        ),
+        (
+            """
+            Short description
+
+            Long description
+            Second line
+            """,
+            "Short description\n\nLong description\nSecond line",
+        ),
+        (
+            "Short description\nLong description",
+            "Short description\nLong description",
+        ),
+        (
+            """
+            Short description
+            Long description
+            """,
+            "Short description\nLong description",
+        ),
+        (
+            "\nShort description\nLong description\n",
+            "Short description\nLong description",
+        ),
+        (
+            """
+            Short description
+            Long description
+            Second line
+            """,
+            "Short description\nLong description\nSecond line",
+        ),
+        (
+            """
+            Short description
+            Meta:
+            -----
+                asd
+            """,
+            "Short description\nMeta:\n-----\n    asd",
+        ),
+        (
+            """
+            Short description
+            Long description
+            Meta:
+            -----
+                asd
+            """,
+            "Short description\nLong description\nMeta:\n-----\n    asd",
+        ),
+        (
+            """
+            Short description
+            First line
+                Second line
+            Meta:
+            -----
+                asd
+            """,
+            "Short description\nFirst line\n    Second line\nMeta:\n-----\n    asd",
+        ),
+        (
+            """
+            Short description
+ 
+            First line
+                Second line
+            Meta:
+            -----
+                asd
+            """,
+            "Short description\n\nFirst line\n    Second line\nMeta:\n-----\n    asd",
+        ),
+        (
+            """
+            Short description
+ 
+            First line
+                Second line
+ 
+            Meta:
+            -----
+                asd
+            """,
+            "Short description\n\nFirst line\n    Second line\n\nMeta:\n-----\n    asd",
+        ),
+        (
+            """
+            Short description
+ 
+            Meta:
+            -----
+                asd
+                    1
+                        2
+                    3
+            """,
+            "Short description\n\nMeta:\n-----\n    asd\n        1\n            2\n        3",
+        ),
+        (
+            """
+            Short description
+ 
+            Meta1:
+            ------
+                asd
+                1
+                    2
+                3
+            Meta2:
+            ------
+                herp
+            Meta3:
+            ------
+                derp
+            """,
+            "Short description\n\nMeta1:\n------\n    asd\n    1\n        2\n    3\nMeta2:\n------\n    herp\nMeta3:\n------\n    derp",
+        ),
+        (
+            """
+            Short description
+ 
+            Parameters:
+            -----------
+                name
+                    description 1
+                priority: int
+                    description 2
+                sender: str, optional
+                    description 3
+                message: str, optional
+                    description 4, defaults to 'hello'
+                multiline: str, optional
+                    long description 5,
+                        defaults to 'bye'
+            """,
+            "Short description\n\nParameters:\n-----------\n"
+            "    name\n        description 1\n"
+            "    priority: int\n        description 2\n"
+            "    sender: str, optional\n        description 3\n"
+            "    message: str, optional\n        description 4, defaults to 'hello'\n"
+            "    multiline: str, optional\n        long description 5,\n"
+            "            defaults to 'bye'",
+        ),
+        (
+            """
+            Short description
+            Raises:
+            -------
+                ValueError
+                    description
+            """,
+            "Short description\nRaises:\n-------\n    ValueError\n        description",
+        ),
+    ],
+)
+def test_unparse(source: str, expected: str) -> None:
+    assert unparse(parse(source)) == expected


### PR DESCRIPTION
This pr has two components:
It up the epydoc parsing module, fixing up mypy errors and slightly simplifying logic, etc. It also adds the ability to unparse a parsed docstring into text across all implemented docstring styles.