### PR TITLE
Add utility to combine docstrings of callables

### DIFF
--- a/docstring_parser/__init__.py
+++ b/docstring_parser/__init__.py
@@ -12,11 +12,13 @@ from .common import (
     RenderingStyle,
 )
 from .parser import compose, parse
+from .util import combine_docstrings
 
 Style = DocstringStyle  # backwards compatibility
 
 __all__ = [
     "parse",
+    "combine_docstrings",
     "compose",
     "ParseError",
     "Docstring",

--- a/docstring_parser/tests/test_util.py
+++ b/docstring_parser/tests/test_util.py
@@ -7,55 +7,58 @@ from docstring_parser.util import combine_docstrings
 def test_combine_docstrings() -> None:
     """Test combine_docstrings wrapper."""
 
-    def fun1(a, b, c, d):
+    def fun1(arg_a, arg_b, arg_c, arg_d):
         """short_description: fun1
 
-        :param a: fun1
-        :param b: fun1
+        :param arg_a: fun1
+        :param arg_b: fun1
         :return: fun1
         """
+        assert arg_a and arg_b and arg_c and arg_d
 
-    def fun2(b, c, d, e):
+    def fun2(arg_b, arg_c, arg_d, arg_e):
         """short_description: fun2
 
         long_description: fun2
 
-        :param b: fun2
-        :param c: fun2
-        :param e: fun2
+        :param arg_b: fun2
+        :param arg_c: fun2
+        :param arg_e: fun2
         """
+        assert arg_b and arg_c and arg_d and arg_e
 
     @combine_docstrings(fun1, fun2)
-    def decorated(a, b, c, d, e, f):
+    def decorated1(arg_a, arg_b, arg_c, arg_d, arg_e, arg_f):
         """
-        :param e: decorated
-        :param f: decorated
+        :param arg_e: decorated
+        :param arg_f: decorated
         """
+        assert arg_a and arg_b and arg_c and arg_d and arg_e and arg_f
 
-    assert decorated.__doc__ == (
+    assert decorated1.__doc__ == (
         "short_description: fun2\n"
         "\n"
         "long_description: fun2\n"
         "\n"
-        ":param a: fun1\n"
-        ":param b: fun1\n"
-        ":param c: fun2\n"
-        ":param e: fun2\n"
-        ":param f: decorated\n"
+        ":param arg_a: fun1\n"
+        ":param arg_b: fun1\n"
+        ":param arg_c: fun2\n"
+        ":param arg_e: fun2\n"
+        ":param arg_f: decorated\n"
         ":returns: fun1"
     )
 
     @combine_docstrings(fun1, fun2, exclude=[DocstringReturns])
-    def decorated(a, b, c, d, e, f):
-        pass
+    def decorated2(arg_a, arg_b, arg_c, arg_d, arg_e, arg_f):
+        assert arg_a and arg_b and arg_c and arg_d and arg_e and arg_f
 
-    assert decorated.__doc__ == (
+    assert decorated2.__doc__ == (
         "short_description: fun2\n"
         "\n"
         "long_description: fun2\n"
         "\n"
-        ":param a: fun1\n"
-        ":param b: fun1\n"
-        ":param c: fun2\n"
-        ":param e: fun2"
+        ":param arg_a: fun1\n"
+        ":param arg_b: fun1\n"
+        ":param arg_c: fun2\n"
+        ":param arg_e: fun2"
     )

--- a/docstring_parser/tests/test_util.py
+++ b/docstring_parser/tests/test_util.py
@@ -1,0 +1,61 @@
+"""Test for utility functions."""
+
+from docstring_parser.common import DocstringReturns
+from docstring_parser.util import combine_docstrings
+
+
+def test_combine_docstrings() -> None:
+    """Test combine_docstrings wrapper."""
+
+    def fun1(a, b, c, d):
+        """short_description: fun1
+
+        :param a: fun1
+        :param b: fun1
+        :return: fun1
+        """
+
+    def fun2(b, c, d, e):
+        """short_description: fun2
+
+        long_description: fun2
+
+        :param b: fun2
+        :param c: fun2
+        :param e: fun2
+        """
+
+    @combine_docstrings(fun1, fun2)
+    def decorated(a, b, c, d, e, f):
+        """
+        :param e: decorated
+        :param f: decorated
+        """
+
+    assert decorated.__doc__ == (
+        "short_description: fun2\n"
+        "\n"
+        "long_description: fun2\n"
+        "\n"
+        ":param a: fun1\n"
+        ":param b: fun1\n"
+        ":param c: fun2\n"
+        ":param e: fun2\n"
+        ":param f: decorated\n"
+        ":returns: fun1"
+    )
+
+    @combine_docstrings(fun1, fun2, exclude=[DocstringReturns])
+    def decorated(a, b, c, d, e, f):
+        pass
+
+    assert decorated.__doc__ == (
+        "short_description: fun2\n"
+        "\n"
+        "long_description: fun2\n"
+        "\n"
+        ":param a: fun1\n"
+        ":param b: fun1\n"
+        ":param c: fun2\n"
+        ":param e: fun2"
+    )

--- a/docstring_parser/util.py
+++ b/docstring_parser/util.py
@@ -100,7 +100,7 @@ def combine_docstrings(
             )
         )
 
-        for doc in docs[::-1]:
+        for doc in reversed(docs):
             if not doc.short_description:
                 continue
             comb_doc.short_description = doc.short_description
@@ -108,7 +108,8 @@ def combine_docstrings(
                 doc.blank_after_short_description
             )
             break
-        for doc in docs[::-1]:
+
+        for doc in reversed(docs):
             if not doc.long_description:
                 continue
             comb_doc.long_description = doc.long_description
@@ -116,6 +117,7 @@ def combine_docstrings(
                 doc.blank_after_long_description
             )
             break
+
         combined = {}
         for doc in docs:
             metas = {}

--- a/docstring_parser/util.py
+++ b/docstring_parser/util.py
@@ -9,7 +9,7 @@ from .common import (
     DocstringParam,
     DocstringReturns,
     DocstringStyle,
-    RenderingStyle
+    RenderingStyle,
 )
 from .parser import compose, parse
 

--- a/docstring_parser/util.py
+++ b/docstring_parser/util.py
@@ -1,0 +1,133 @@
+"""Utility functions for working with docstrings."""
+import typing as T
+
+from .common import (
+    DocstringStyle,
+    DocstringMeta,
+    DocstringParam,
+    DocstringReturns,
+)
+from .parser import compose, parse
+
+_Func = T.Callable[..., T.Any]
+
+assert DocstringReturns  # used in docstring
+
+
+def combine_docstrings(
+    *others: _Func,
+    style: DocstringStyle = DocstringStyle.AUTO,
+    exclude: T.Iterable[DocstringMeta] = ()
+) -> _Func:
+    """A function decorator that parses the docstrings from `others`,
+    programmatically combines them with the parsed docstring of the decorated
+    function, and replaces the docstring of the decorated function with the
+    composed result. Only parameters that are part of the decorated functions
+    signature are included in the combined docstring. When multiple sources for
+    a parameter or docstring metadata exists then the decorator will first
+    default to the wrapped function's value (when available) and otherwise use
+    the rightmost definition from ``others``.
+
+    The following example illustrates its usage:
+
+    >>> def fun1(a, b, c, d):
+    ...    '''short_description: fun1
+    ...
+    ...    :param a: fun1
+    ...    :param b: fun1
+    ...    :return: fun1
+    ...    '''
+    >>> def fun2(b, c, d, e):
+    ...    '''short_description: fun2
+    ...
+    ...    long_description: fun2
+    ...
+    ...    :param b: fun2
+    ...    :param c: fun2
+    ...    :param e: fun2
+    ...    '''
+    >>> @combine_docstrings(fun1, fun2)
+    >>> def decorated(a, b, c, d, e, f):
+    ...     '''
+    ...     :param e: decorated
+    ...     :param f: decorated
+    ...     '''
+    >>> print(decorated.__doc__)
+    short_description: fun2
+    <BLANKLINE>
+    long_description: fun2
+    <BLANKLINE>
+    :param a: fun1
+    :param b: fun1
+    :param c: fun2
+    :param e: fun2
+    :param f: decorated
+    :returns: fun1
+    >>> @combine_docstrings(fun1, fun2, exclude=[DocstringReturns])
+    >>> def decorated(a, b, c, d, e, f): pass
+    >>> print(decorated.__doc__)
+    short_description: fun2
+    <BLANKLINE>
+    long_description: fun2
+    <BLANKLINE>
+    :param a: fun1
+    :param b: fun1
+    :param c: fun2
+    :param e: fun2
+
+    :param others: callables from which to parse docstrings.
+    :param style: style composed docstring. The default will infer the style
+    from the decorated function.
+    :param exclude: an iterable of ``DocstringMeta`` subclasses to exclude when
+    combining docstrings.
+    :return: the decorated function with a modified docstring.
+    """
+    from collections import ChainMap
+    from inspect import Signature
+    from itertools import chain
+
+    def wrapper(func: _Func) -> _Func:
+        sig = Signature.from_callable(func)
+
+        doc = parse(func.__doc__ or "")
+        docs = [parse(other.__doc__ or "") for other in others] + [doc]
+        params = dict(
+            ChainMap(
+                *(
+                    {param.arg_name: param for param in doc.params}
+                    for doc in docs
+                )
+            )
+        )
+
+        for d in docs[::-1]:
+            if not d.short_description:
+                continue
+            doc.short_description = d.short_description
+            doc.blank_after_short_description = d.blank_after_short_description
+            break
+        for d in docs[::-1]:
+            if not d.long_description:
+                continue
+            doc.long_description = d.long_description
+            doc.blank_after_long_description = d.blank_after_long_description
+            break
+        combined = {}
+        for d in docs:
+            metas = {}
+            for meta in d.meta:
+                meta_type = type(meta)
+                if meta_type in exclude:
+                    continue
+                metas.setdefault(meta_type, []).append(meta)
+            for (meta_type, meta) in metas.items():
+                combined[meta_type] = meta
+
+        combined[DocstringParam] = [
+            params[name] for name in sig.parameters if name in params
+        ]
+        doc.meta = list(chain(*combined.values()))
+        func.__doc__ = compose(doc, style=style)
+        return func
+
+    return wrapper

--- a/docstring_parser/util.py
+++ b/docstring_parser/util.py
@@ -20,7 +20,7 @@ assert DocstringReturns  # used in docstring
 def combine_docstrings(
     *others: _Func,
     style: DocstringStyle = DocstringStyle.AUTO,
-    exclude: T.Iterable[DocstringMeta] = ()
+    exclude: T.Iterable[T.Type[DocstringMeta]] = ()
 ) -> _Func:
     """A function decorator that parses the docstrings from `others`,
     programmatically combines them with the parsed docstring of the decorated

--- a/docstring_parser/util.py
+++ b/docstring_parser/util.py
@@ -9,6 +9,7 @@ from .common import (
     DocstringParam,
     DocstringReturns,
     DocstringStyle,
+    RenderingStyle
 )
 from .parser import compose, parse
 
@@ -19,8 +20,9 @@ assert DocstringReturns  # used in docstring
 
 def combine_docstrings(
     *others: _Func,
+    exclude: T.Iterable[T.Type[DocstringMeta]] = (),
     style: DocstringStyle = DocstringStyle.AUTO,
-    exclude: T.Iterable[T.Type[DocstringMeta]] = ()
+    rendering_style: RenderingStyle = RenderingStyle.COMPACT,
 ) -> _Func:
     """A function decorator that parses the docstrings from `others`,
     programmatically combines them with the parsed docstring of the decorated
@@ -79,10 +81,11 @@ def combine_docstrings(
     :param e: fun2
 
     :param others: callables from which to parse docstrings.
-    :param style: style composed docstring. The default will infer the style
-    from the decorated function.
     :param exclude: an iterable of ``DocstringMeta`` subclasses to exclude when
     combining docstrings.
+    :param style: style composed docstring. The default will infer the style
+    from the decorated function.
+    :param rendering_style: The rendering style used to compose a docstring.
     :return: the decorated function with a modified docstring.
     """
 
@@ -133,7 +136,9 @@ def combine_docstrings(
             params[name] for name in sig.parameters if name in params
         ]
         comb_doc.meta = list(chain(*combined.values()))
-        func.__doc__ = compose(comb_doc, style=style)
+        func.__doc__ = compose(
+            comb_doc, style=style, rendering_style=rendering_style
+        )
         return func
 
     return wrapper


### PR DESCRIPTION
Add a function decorator that programmatically combines function docstrings from specified functions with that of the wrapped function.