### PR TITLE
fix(numpydoc): don't allow non-whitespace in front of "default"

### DIFF
--- a/docstring_parser/numpydoc.py
+++ b/docstring_parser/numpydoc.py
@@ -42,7 +42,7 @@ PARAM_OPTIONAL_REGEX = re.compile(r"(?P<type>.*?)(?:, optional|\(optional\))$")
 # numpydoc format has no formal grammar for this,
 # but we can make some educated guesses...
 PARAM_DEFAULT_REGEX = re.compile(
-    r"[Dd]efault(?: is | = |: |s to |)\s*(?P<value>[\w\-\.]+)"
+    r"(?<!\S)[Dd]efault(?: is | = |: |s to |)\s*(?P<value>[\w\-\.]+)"
 )
 
 RETURN_KEY_REGEX = re.compile(r"^(?:(?P<name>.*?)\s*:\s*)?(?P<type>.*?)$")

--- a/docstring_parser/tests/test_numpydoc.py
+++ b/docstring_parser/tests/test_numpydoc.py
@@ -263,6 +263,27 @@ def test_default_args() -> None:
     assert arg4.description == "The fourth arg. Defaults to None"
 
 
+def test_default_args_negative() -> None:
+    """Test parsing default arguments."""
+    docstring = parse(
+        """
+        Parameters
+        ----------
+        parameter_without_default : int
+            The parameter_without_default is required.
+        """
+    )
+    assert docstring is not None
+    assert len(docstring.params) == 1
+
+    arg1 = docstring.params[0]
+    assert arg1.arg_name == "parameter_without_default"
+    assert not arg1.is_optional
+    assert arg1.type_name == "int"
+    assert arg1.default is None
+    assert arg1.description == "The parameter_without_default is required."
+
+
 def test_multiple_meta() -> None:
     """Test parsing multiple meta."""
     docstring = parse(


### PR DESCRIPTION
Improve the detection of the default value in the description of a parameter for the `numpydoc` style. Now there must either be whitespace or nothing in front of "default"/"Default".