### PR TITLE
Attribute parsing for epydoc parser

### DIFF
--- a/docstring_parser/epydoc.py
+++ b/docstring_parser/epydoc.py
@@ -131,7 +131,7 @@ def parse(text: str) -> Docstring:
     # Combine type_name, arg_name, and description information
     params: T.Dict[str, T.Dict[str, T.Any]] = {}
     for (base, key, args, desc) in stream:
-        if base not in ["param", "attribute", "return"]:
+        if base not in {"param", "attribute", "return"}:
             continue  # nothing to do
 
         (arg_name,) = args or ("return",)
@@ -148,7 +148,7 @@ def parse(text: str) -> Docstring:
 
     is_done: T.Dict[str, bool] = {}
     for (base, key, args, desc) in stream:
-        if base in ["param", "attribute"] and not is_done.get(args[0], False):
+        if base in {"param", "attribute"} and not is_done.get(args[0], False):
             (arg_name,) = args
             info = params[arg_name]
             type_name = info.get("type_name")

--- a/docstring_parser/tests/test_epydoc.py
+++ b/docstring_parser/tests/test_epydoc.py
@@ -303,6 +303,65 @@ def test_params() -> None:
     assert docstring.params[4].default == "'bye'"
 
 
+def test_attributes() -> None:
+    """Test parsing attributes."""
+    docstring = parse("Short description")
+    assert len(docstring.params) == 0
+
+    docstring = parse(
+        """
+        Short description
+
+        @ivar name: description 1
+        @ivar priority: description 2
+        @type priority: int
+        @cvar sender: description 3
+        @type sender: str?
+        @var message: description 4, defaults to 'hello'
+        @type message: str?
+        @var multiline: long description 5,
+        defaults to 'bye'
+        @type multiline: str?
+        """
+    )
+    assert len(docstring.params) == 5
+    assert docstring.params[0].arg_name == "name"
+    assert docstring.params[0].args[0] == "ivar"
+    assert docstring.params[0].type_name is None
+    assert docstring.params[0].description == "description 1"
+    assert docstring.params[0].default is None
+    assert not docstring.params[0].is_optional
+    assert docstring.params[1].arg_name == "priority"
+    assert docstring.params[1].args[0] == "ivar"
+    assert docstring.params[1].type_name == "int"
+    assert docstring.params[1].description == "description 2"
+    assert not docstring.params[1].is_optional
+    assert docstring.params[1].default is None
+    assert docstring.params[2].arg_name == "sender"
+    assert docstring.params[2].args[0] == "cvar"
+    assert docstring.params[2].type_name == "str"
+    assert docstring.params[2].description == "description 3"
+    assert docstring.params[2].is_optional
+    assert docstring.params[2].default is None
+    assert docstring.params[3].arg_name == "message"
+    assert docstring.params[3].args[0] == "var"
+    assert docstring.params[3].type_name == "str"
+    assert (
+        docstring.params[3].description == "description 4, defaults to 'hello'"
+    )
+    assert docstring.params[3].is_optional
+    assert docstring.params[3].default == "'hello'"
+    assert docstring.params[4].arg_name == "multiline"
+    assert docstring.params[4].type_name == "str"
+    assert docstring.params[4].args[0] == "var"
+    assert (
+        docstring.params[4].description
+        == "long description 5,\ndefaults to 'bye'"
+    )
+    assert docstring.params[4].is_optional
+    assert docstring.params[4].default == "'bye'"
+
+
 def test_returns() -> None:
     """Test parsing returns."""
     docstring = parse(


### PR DESCRIPTION
Added missing attribute parsing for the epydoc parser, which includes the "@ivar", "@cvar" and "@var" syntax.