### PR TITLE
Remove deprecated and to be removed (in 3.14) old Ast classes

### DIFF
--- a/docstring_parser/attrdoc.py
+++ b/docstring_parser/attrdoc.py
@@ -34,7 +34,7 @@ def ast_unparse(node: ast.AST) -> T.Optional[str]:
     if hasattr(ast, "unparse"):
         return ast.unparse(node)
     # Support simple cases in Python < 3.9
-    if isinstance(node, (ast.Str, ast.Num, ast.NameConstant, ast.Constant)):
+    if isinstance(node, (ast.Constant)):
         return str(ast_get_constant_value(node))
     if isinstance(node, ast.Name):
         return node.id
@@ -45,7 +45,7 @@ def ast_is_literal_str(node: ast.AST) -> bool:
     """Return True if the given node is a literal string."""
     return (
         isinstance(node, ast.Expr)
-        and isinstance(node.value, (ast.Constant, ast.Str))
+        and isinstance(node.value, (ast.Constant))
         and isinstance(ast_get_constant_value(node.value), str)
     )
 


### PR DESCRIPTION
Ast.Num, Ast.Str and Ast.NameConstant are deprecated since 3.8 and are removed in (early beta already) 3.14 as per https://docs.python.org/3/library/ast.html#ast.AST and Ast.Constant should be used.

I'm not sure if you strive for maintaining some backwards compatibility (pre 3.8 then?) in which case Maybe we'd need to elaborate additionally the MR with some versions checks.