### PR TITLE
Fix: Handle multi-line parameter definitions in GoogleParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.gitignore
 __pycache__
 *.egg-info
-poetry.lock
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/pycqa/pylint
-  rev: v2.13.7
+  rev: v3.3.7
   hooks:
   - id: pylint
     additional_dependencies: [toml]

--- a/docstring_parser/google.py
+++ b/docstring_parser/google.py
@@ -113,6 +113,12 @@ class GoogleParser:
 
         # Split spec and description
         before, desc = text.split(":", 1)
+
+        if before and "\n" in before:
+            # If there is a newline in the first line, clean it up
+            first_line, rest = before.split("\n", 1)
+            before = first_line + inspect.cleandoc(rest)
+
         if desc:
             desc = desc[1:] if desc[0] == " " else desc
             if "\n" in desc:

--- a/docstring_parser/tests/test_google.py
+++ b/docstring_parser/tests/test_google.py
@@ -28,6 +28,28 @@ def test_google_parser_unknown_section() -> None:
     assert len(docstring.meta) == 0
 
 
+def test_google_parser_multi_line_parameter_type() -> None:
+    """Test parsing a multi-line parameter type with default GoogleParser"""
+    parser = GoogleParser()
+    docstring = parser.parse(
+        """Description of the function.
+
+        Args:
+            output_type (Literal["searchResults", "sourcedAnswer",
+                "structured"]): The type of output.
+                This can be one of the following:
+                - "searchResults": Represents the search results.
+                - "sourcedAnswer": Represents a sourced answer.
+                - "structured": Represents a structured output format.
+
+        Returns:
+            bool: Indicates success or failure.
+
+        """
+    )
+    assert docstring.params[0].arg_name == "output_type"
+
+
 def test_google_parser_custom_sections() -> None:
     """Test parsing an unknown section with custom GoogleParser
     configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,5 +74,6 @@ disable = [
     "too-many-branches",
     "too-many-statements",
     "too-many-arguments",
+    "too-many-positional-arguments",
     "too-few-public-methods",
 ]


### PR DESCRIPTION
close #97 