### PR TITLE
Allowing `parse` to work with missing `__doc__`

### DIFF
--- a/docstring_parser/epydoc.py
+++ b/docstring_parser/epydoc.py
@@ -26,7 +26,7 @@ def _clean_str(string: str) -> T.Optional[str]:
     return None
 
 
-def parse(text: str) -> Docstring:
+def parse(text: str | None) -> Docstring:
     """Parse the epydoc-style docstring into its components.
 
     :returns: parsed docstring

--- a/docstring_parser/google.py
+++ b/docstring_parser/google.py
@@ -202,7 +202,7 @@ class GoogleParser:
         self.sections[section.title] = section
         self._setup()
 
-    def parse(self, text: str) -> Docstring:
+    def parse(self, text: str | None) -> Docstring:
         """Parse the Google-style docstring into its components.
 
         :returns: parsed docstring
@@ -293,7 +293,7 @@ class GoogleParser:
         return ret
 
 
-def parse(text: str) -> Docstring:
+def parse(text: str | None) -> Docstring:
     """Parse the Google-style docstring into its components.
 
     :returns: parsed docstring

--- a/docstring_parser/numpydoc.py
+++ b/docstring_parser/numpydoc.py
@@ -325,7 +325,7 @@ class NumpydocParser:
         self.sections[section.title] = section
         self._setup()
 
-    def parse(self, text: str) -> Docstring:
+    def parse(self, text: str | None) -> Docstring:
         """Parse the numpy-style docstring into its components.
 
         :returns: parsed docstring
@@ -370,7 +370,7 @@ class NumpydocParser:
         return ret
 
 
-def parse(text: str) -> Docstring:
+def parse(text: str | None) -> Docstring:
     """Parse the numpy-style docstring into its components.
 
     :returns: parsed docstring

--- a/docstring_parser/parser.py
+++ b/docstring_parser/parser.py
@@ -20,7 +20,9 @@ _STYLE_MAP = {
 }
 
 
-def parse(text: str, style: DocstringStyle = DocstringStyle.AUTO) -> Docstring:
+def parse(
+    text: str | None, style: DocstringStyle = DocstringStyle.AUTO
+) -> Docstring:
     """Parse the docstring into its components.
 
     :param text: docstring text to parse

--- a/docstring_parser/rest.py
+++ b/docstring_parser/rest.py
@@ -99,7 +99,7 @@ def _build_meta(args: T.List[str], desc: str) -> DocstringMeta:
     return DocstringMeta(args=args, description=desc)
 
 
-def parse(text: str) -> Docstring:
+def parse(text: str | None) -> Docstring:
     """Parse the ReST-style docstring into its components.
 
     :returns: parsed docstring

--- a/docstring_parser/tests/test_epydoc.py
+++ b/docstring_parser/tests/test_epydoc.py
@@ -10,6 +10,7 @@ from docstring_parser.epydoc import compose, parse
 @pytest.mark.parametrize(
     "source, expected",
     [
+        pytest.param(None, None, id="No __doc__"),
         ("", None),
         ("\n", None),
         ("Short description", "Short description"),
@@ -17,7 +18,7 @@ from docstring_parser.epydoc import compose, parse
         ("\n   Short description\n", "Short description"),
     ],
 )
-def test_short_description(source: str, expected: str) -> None:
+def test_short_description(source: str | None, expected: str | None) -> None:
     """Test parsing short description."""
     docstring = parse(source)
     assert docstring.short_description == expected

--- a/docstring_parser/tests/test_google.py
+++ b/docstring_parser/tests/test_google.py
@@ -143,6 +143,7 @@ def test_google_parser_custom_sections_after() -> None:
 @pytest.mark.parametrize(
     "source, expected",
     [
+        pytest.param(None, None, id="No __doc__"),
         ("", None),
         ("\n", None),
         ("Short description", "Short description"),
@@ -150,7 +151,7 @@ def test_google_parser_custom_sections_after() -> None:
         ("\n   Short description\n", "Short description"),
     ],
 )
-def test_short_description(source: str, expected: str) -> None:
+def test_short_description(source: str | None, expected: str | None) -> None:
     """Test parsing short description."""
     docstring = parse(source)
     assert docstring.short_description == expected

--- a/docstring_parser/tests/test_numpydoc.py
+++ b/docstring_parser/tests/test_numpydoc.py
@@ -9,6 +9,7 @@ from docstring_parser.numpydoc import compose, parse
 @pytest.mark.parametrize(
     "source, expected",
     [
+        pytest.param(None, None, id="No __doc__"),
         ("", None),
         ("\n", None),
         ("Short description", "Short description"),
@@ -16,7 +17,7 @@ from docstring_parser.numpydoc import compose, parse
         ("\n   Short description\n", "Short description"),
     ],
 )
-def test_short_description(source: str, expected: str) -> None:
+def test_short_description(source: str | None, expected: str | None) -> None:
     """Test parsing short description."""
     docstring = parse(source)
     assert docstring.short_description == expected

--- a/docstring_parser/tests/test_parser.py
+++ b/docstring_parser/tests/test_parser.py
@@ -5,6 +5,26 @@ from docstring_parser.common import DocstringStyle, ParseError
 from docstring_parser.parser import parse
 
 
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        pytest.param(None, None, id="No __doc__"),
+        ("", None),
+        ("\n", None),
+        ("Short description", "Short description"),
+        ("\nShort description\n", "Short description"),
+        ("\n   Short description\n", "Short description"),
+    ],
+)
+def test_short_description(source: str | None, expected: str | None) -> None:
+    """Test parsing short description."""
+    docstring = parse(source)
+    assert docstring.short_description == expected
+    assert docstring.description == expected
+    assert docstring.long_description is None
+    assert not docstring.meta
+
+
 def test_rest() -> None:
     """Test ReST-style parser autodetection."""
     docstring = parse(

--- a/docstring_parser/tests/test_rest.py
+++ b/docstring_parser/tests/test_rest.py
@@ -10,6 +10,7 @@ from docstring_parser.rest import compose, parse
 @pytest.mark.parametrize(
     "source, expected",
     [
+        pytest.param(None, None, id="No __doc__"),
         ("", None),
         ("\n", None),
         ("Short description", "Short description"),
@@ -17,7 +18,7 @@ from docstring_parser.rest import compose, parse
         ("\n   Short description\n", "Short description"),
     ],
 )
-def test_short_description(source: str, expected: str) -> None:
+def test_short_description(source: str | None, expected: str | None) -> None:
     """Test parsing short description."""
     docstring = parse(source)
     assert docstring.short_description == expected


### PR DESCRIPTION
Closes https://github.com/rr-/docstring_parser/issues/88